### PR TITLE
Fixed version bumping when no line break after version was present.

### DIFF
--- a/src/main/groovy/org/mockito/release/version/DefaultVersionFile.java
+++ b/src/main/groovy/org/mockito/release/version/DefaultVersionFile.java
@@ -41,6 +41,11 @@ class DefaultVersionFile implements VersionFile {
         VersionBumper bumper = new VersionBumper();
         version = bumper.incrementVersion(this.version);
         String content = IOUtil.readFully(versionFile);
+        if (!content.endsWith("\n")) {
+            //This makes the regex simpler. Add arbitrary end of line at the end of file should not bother anyone.
+            //See also unit tests for this class
+            content += "\n";
+        }
         String updated = content.replaceAll("(?m)^version=(.*?)\n", "version=" + version + "\n");
         IOUtil.writeFile(versionFile, updated);
         return version;

--- a/src/test/groovy/org/mockito/release/version/DefaultVersionFileTest.groovy
+++ b/src/test/groovy/org/mockito/release/version/DefaultVersionFileTest.groovy
@@ -3,7 +3,6 @@ package org.mockito.release.version
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-import spock.lang.Subject
 
 class DefaultVersionFileTest extends Specification {
 
@@ -46,5 +45,15 @@ version=2.0.1
 x
 """
         v.version == "2.0.1"
+    }
+
+    def "increments correctly even if no line break after version"() {
+        def f = dir.newFile() << "foo=bar\nversion=2.0.0"
+
+        when:
+        new DefaultVersionFile(f).incrementVersion()
+
+        then:
+        f.text == "foo=bar\nversion=2.0.1\n"
     }
 }


### PR DESCRIPTION
Fixes issue #1