### PR TITLE
Progress on concise release notes

### DIFF
--- a/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
+++ b/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
@@ -38,7 +38,7 @@ class GitNotesBuilder implements NotesBuilder {
     public String buildNotes(String version, String fromRevision, String toRevision, final Map<String, String> labels) {
         LOG.info("Getting release notes between {} and {}", fromRevision, toRevision);
 
-        ContributionsProvider contributionsProvider = Vcs.getGitProvider(Exec.getProcessRunner(workDir));
+        ContributionsProvider contributionsProvider = Vcs.getContributionsProvider(Exec.getProcessRunner(workDir));
         ContributionSet contributions = contributionsProvider.getContributionsBetween(fromRevision, toRevision);
 
         ImprovementsProvider improvementsProvider = Improvements.getGitHubProvider(authTokenEnvVar);

--- a/src/main/groovy/org/mockito/release/notes/format/ConciseFormatter.java
+++ b/src/main/groovy/org/mockito/release/notes/format/ConciseFormatter.java
@@ -1,11 +1,8 @@
 package org.mockito.release.notes.format;
 
+import org.mockito.release.notes.internal.DateFormat;
 import org.mockito.release.notes.model.Improvement;
 import org.mockito.release.notes.model.ReleaseNotesData;
-
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
 
 class ConciseFormatter implements MultiReleaseNotesFormatter {
 
@@ -18,7 +15,7 @@ class ConciseFormatter implements MultiReleaseNotesFormatter {
     public String formatReleaseNotes(Iterable<ReleaseNotesData> data) {
         StringBuilder sb = new StringBuilder(introductionText);
         for (ReleaseNotesData d : data) {
-            sb.append("### ").append(d.getVersion()).append(" - ").append(formatDate(d.getDate()))
+            sb.append("### ").append(d.getVersion()).append(" - ").append(DateFormat.formatDate(d.getDate()))
                     .append("\n\n");
 
             for (Improvement i : d.getImprovements()) {
@@ -30,12 +27,5 @@ class ConciseFormatter implements MultiReleaseNotesFormatter {
         }
 
         return sb.toString();
-    }
-
-    private static String formatDate(Date date) {
-        //TODO SF reuse and unify
-        SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd HH:mm");
-        f.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return f.format(date);
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/format/DefaultFormatter.java
+++ b/src/main/groovy/org/mockito/release/notes/format/DefaultFormatter.java
@@ -1,12 +1,12 @@
 package org.mockito.release.notes.format;
 
+import org.mockito.release.notes.internal.DateFormat;
 import org.mockito.release.notes.model.Contribution;
 import org.mockito.release.notes.model.ContributionSet;
 import org.mockito.release.notes.model.Improvement;
 import org.mockito.release.notes.model.ReleaseNotesData;
 import org.mockito.release.util.MultiMap;
 
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 /**
@@ -83,9 +83,7 @@ class DefaultFormatter implements SingleReleaseNotesFormatter {
     }
 
     public String formatVersion(ReleaseNotesData data) {
-        SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd HH:mm z");
-        f.setTimeZone(TimeZone.getTimeZone("UTC"));
-        String now = f.format(data.getDate());
+        String now = DateFormat.formatDate(data.getDate());
 
         return "### " + data.getVersion() + " (" + now + ")" + "\n\n"
                 + format(data.getContributions()) + "\n"

--- a/src/main/groovy/org/mockito/release/notes/generator/DefaultReleaseNotesGenerator.java
+++ b/src/main/groovy/org/mockito/release/notes/generator/DefaultReleaseNotesGenerator.java
@@ -41,7 +41,7 @@ class DefaultReleaseNotesGenerator implements ReleaseNotesGenerator {
             Collection<Improvement> improvements = improvementsProvider.getImprovements(contributions, gitHubLabels, onlyPullRequests);
             out.add(new DefaultReleaseNotesData(to, releaseDates.get(to), contributions, improvements));
 
-            //next round
+            //next version
             to = v;
         }
 

--- a/src/main/groovy/org/mockito/release/notes/generator/ReleaseNotesGenerators.java
+++ b/src/main/groovy/org/mockito/release/notes/generator/ReleaseNotesGenerators.java
@@ -14,7 +14,7 @@ public class ReleaseNotesGenerators {
 
     public static ReleaseNotesGenerator releaseNotesGenerator(File workDir, String authToken) {
         ProcessRunner processRunner = Exec.getProcessRunner(workDir);
-        ContributionsProvider contributionsProvider = Vcs.getGitProvider(processRunner);
+        ContributionsProvider contributionsProvider = Vcs.getContributionsProvider(processRunner);
         ImprovementsProvider improvementsProvider = Improvements.getGitHubProvider(authToken);
         ReleaseDateProvider releaseDateProvider = Vcs.getReleaseDateProvider(processRunner);
         return new DefaultReleaseNotesGenerator(contributionsProvider, improvementsProvider, releaseDateProvider);

--- a/src/main/groovy/org/mockito/release/notes/generator/ReleaseNotesGenerators.java
+++ b/src/main/groovy/org/mockito/release/notes/generator/ReleaseNotesGenerators.java
@@ -1,9 +1,11 @@
 package org.mockito.release.notes.generator;
 
 import org.mockito.release.exec.Exec;
+import org.mockito.release.exec.ProcessRunner;
 import org.mockito.release.notes.improvements.Improvements;
 import org.mockito.release.notes.improvements.ImprovementsProvider;
 import org.mockito.release.notes.vcs.ContributionsProvider;
+import org.mockito.release.notes.vcs.ReleaseDateProvider;
 import org.mockito.release.notes.vcs.Vcs;
 
 import java.io.File;
@@ -11,8 +13,10 @@ import java.io.File;
 public class ReleaseNotesGenerators {
 
     public static ReleaseNotesGenerator releaseNotesGenerator(File workDir, String authToken) {
-        ContributionsProvider contributionsProvider = Vcs.getGitProvider(Exec.getProcessRunner(workDir));
+        ProcessRunner processRunner = Exec.getProcessRunner(workDir);
+        ContributionsProvider contributionsProvider = Vcs.getGitProvider(processRunner);
         ImprovementsProvider improvementsProvider = Improvements.getGitHubProvider(authToken);
-        return new DefaultReleaseNotesGenerator(contributionsProvider, improvementsProvider);
+        ReleaseDateProvider releaseDateProvider = Vcs.getReleaseDateProvider(processRunner);
+        return new DefaultReleaseNotesGenerator(contributionsProvider, improvementsProvider, releaseDateProvider);
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/internal/DateFormat.java
+++ b/src/main/groovy/org/mockito/release/notes/internal/DateFormat.java
@@ -1,0 +1,34 @@
+package org.mockito.release.notes.internal;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * Date parsing and formatting utilities
+ */
+public class DateFormat {
+
+    /**
+     * Parses date in iso format, e.g. "yyyy-MM-dd HH:mm:ss Z"
+     */
+    public static Date parseDate(String date) {
+        String pattern = "yyyy-MM-dd HH:mm:ss Z";
+        SimpleDateFormat format = new SimpleDateFormat(pattern);
+        try {
+            return format.parse(date.trim());
+        } catch (ParseException e) {
+            throw new RuntimeException("Problems parsing date: '" + date + "'. Required format is: '" + pattern + "'.", e);
+        }
+    }
+
+    /**
+     * Parses date in iso format, e.g. "yyyy-MM-dd HH:mm:ss Z"
+     */
+    public static String formatDate(Date date) {
+        SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        f.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return f.format(date);
+    }
+}

--- a/src/main/groovy/org/mockito/release/notes/internal/DateFormat.java
+++ b/src/main/groovy/org/mockito/release/notes/internal/DateFormat.java
@@ -19,7 +19,7 @@ public class DateFormat {
         try {
             return format.parse(date.trim());
         } catch (ParseException e) {
-            throw new RuntimeException("Problems parsing date: '" + date + "'. Required format is: '" + pattern + "'.", e);
+            throw new RuntimeException("Problems parsing date: [" + date + "]. Required format is: [" + pattern + "].", e);
         }
     }
 

--- a/src/main/groovy/org/mockito/release/notes/vcs/DefaultReleaseDateProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/vcs/DefaultReleaseDateProvider.java
@@ -1,0 +1,45 @@
+package org.mockito.release.notes.vcs;
+
+import org.mockito.release.exec.ProcessRunner;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+class DefaultReleaseDateProvider implements ReleaseDateProvider {
+
+    private final ProcessRunner runner;
+
+    DefaultReleaseDateProvider(ProcessRunner runner) {
+        this.runner = runner;
+    }
+
+    @Override
+    public Map<String, Date> getReleaseDates(Iterable<String> versions, String tagPrefix) {
+        //TODO SF use this to get version of a tag:
+        //git log --simplify-by-decoration --pretty="format:%ai %d" v2.6.1..v2.7.0
+        //git log --simplify-by-decoration --pretty="format:%ai %d" <tag prefix + last element of versions>..<tag prefix + first element of versions>
+        //example result from mockito:
+        /*
+~/mockito/src$ git log --simplify-by-decoration --pretty="format:%ai %d" v2.6.1..v2.7.0
+2017-01-29 08:14:09 -0800  (tag: v2.7.0)
+2017-01-23 21:28:50 -0800  (origin/strict-stubbing, strict-stubbing)
+2017-01-27 22:02:58 +0000  (tag: v2.6.9)
+2017-01-23 14:53:02 +0000  (tag: v2.6.8)
+2017-01-23 13:52:08 +0000  (tag: v2.6.7)
+2017-01-23 10:12:22 +0000  (tag: v2.6.6)
+2017-01-23 11:07:23 +0100
+2017-01-20 14:50:39 +0100  (origin/fix-878-spy-annotation-abstract-class)
+2017-01-21 12:58:32 +0000  (tag: v2.6.5)
+2017-01-19 17:12:14 +0000  (tag: v2.6.4)
+2017-01-15 21:07:48 +0000  (tag: v2.6.3)
+2017-01-13 10:58:06 +0000  (tag: v2.6.2)
+         */
+
+        Map<String, Date> out = new HashMap<String, Date>();
+        for (String version : versions) {
+            out.put(version, new Date());
+        }
+        return out;
+    }
+}

--- a/src/main/groovy/org/mockito/release/notes/vcs/DefaultReleaseDateProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/vcs/DefaultReleaseDateProvider.java
@@ -2,9 +2,12 @@ package org.mockito.release.notes.vcs;
 
 import org.mockito.release.exec.ProcessRunner;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.mockito.release.notes.internal.DateFormat.parseDate;
 
 class DefaultReleaseDateProvider implements ReleaseDateProvider {
 
@@ -15,31 +18,16 @@ class DefaultReleaseDateProvider implements ReleaseDateProvider {
     }
 
     @Override
-    public Map<String, Date> getReleaseDates(Iterable<String> versions, String tagPrefix) {
-        //TODO SF use this to get version of a tag:
-        //git log --simplify-by-decoration --pretty="format:%ai %d" v2.6.1..v2.7.0
-        //git log --simplify-by-decoration --pretty="format:%ai %d" <tag prefix + last element of versions>..<tag prefix + first element of versions>
-        //example result from mockito:
-        /*
-~/mockito/src$ git log --simplify-by-decoration --pretty="format:%ai %d" v2.6.1..v2.7.0
-2017-01-29 08:14:09 -0800  (tag: v2.7.0)
-2017-01-23 21:28:50 -0800  (origin/strict-stubbing, strict-stubbing)
-2017-01-27 22:02:58 +0000  (tag: v2.6.9)
-2017-01-23 14:53:02 +0000  (tag: v2.6.8)
-2017-01-23 13:52:08 +0000  (tag: v2.6.7)
-2017-01-23 10:12:22 +0000  (tag: v2.6.6)
-2017-01-23 11:07:23 +0100
-2017-01-20 14:50:39 +0100  (origin/fix-878-spy-annotation-abstract-class)
-2017-01-21 12:58:32 +0000  (tag: v2.6.5)
-2017-01-19 17:12:14 +0000  (tag: v2.6.4)
-2017-01-15 21:07:48 +0000  (tag: v2.6.3)
-2017-01-13 10:58:06 +0000  (tag: v2.6.2)
-         */
-
+    public Map<String, Date> getReleaseDates(Collection<String> versions, String tagPrefix) {
         Map<String, Date> out = new HashMap<String, Date>();
-        for (String version : versions) {
-            out.put(version, new Date());
+        for (String version: versions) {
+            String tag = tagPrefix + version;
+            String date = runner.run("git", "log", "--pretty=%ad", "--date=iso", tag, "-n", "1");
+            //example output returned by running git command: 2017-01-29 08:14:09 -0800
+            Date d = parseDate(date.trim());
+            out.put(version, d);
         }
+
         return out;
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/vcs/ReleaseDateProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/vcs/ReleaseDateProvider.java
@@ -1,5 +1,6 @@
 package org.mockito.release.notes.vcs;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 
@@ -9,12 +10,11 @@ import java.util.Map;
 public interface ReleaseDateProvider {
 
     /**
-     * Provides release dates for given versions. Versions should be ordered newer first.
-     * Last version is not included in the result. It is only used to calculate version range when getting data from Git.
+     * Provides release dates for given versions.
      *
-     * @param versions for example: 1.2.0, 1.1.0, 1.0.0. Last version is not included in result.
+     * @param versions for example: 1.2.0, 1.1.0, 1.0.0
      * @param tagPrefix optional tag prefix, adding it to the version String should create vcs addressable revision, tag.
      *                  Typically it is "v" or empty String if no tag prefix is used.
      */
-    Map<String, Date> getReleaseDates(Iterable<String> versions, String tagPrefix);
+    Map<String, Date> getReleaseDates(Collection<String> versions, String tagPrefix);
 }

--- a/src/main/groovy/org/mockito/release/notes/vcs/ReleaseDateProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/vcs/ReleaseDateProvider.java
@@ -1,0 +1,20 @@
+package org.mockito.release.notes.vcs;
+
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * Provides release dates for versions
+ */
+public interface ReleaseDateProvider {
+
+    /**
+     * Provides release dates for given versions. Versions should be ordered newer first.
+     * Last version is not included in the result. It is only used to calculate version range when getting data from Git.
+     *
+     * @param versions for example: 1.2.0, 1.1.0, 1.0.0. Last version is not included in result.
+     * @param tagPrefix optional tag prefix, adding it to the version String should create vcs addressable revision, tag.
+     *                  Typically it is "v" or empty String if no tag prefix is used.
+     */
+    Map<String, Date> getReleaseDates(Iterable<String> versions, String tagPrefix);
+}

--- a/src/main/groovy/org/mockito/release/notes/vcs/Vcs.java
+++ b/src/main/groovy/org/mockito/release/notes/vcs/Vcs.java
@@ -8,9 +8,9 @@ import org.mockito.release.exec.ProcessRunner;
 public class Vcs {
 
     /**
-     * Provides means to get contributions. TODO SF rename method
+     * Provides means to get contributions.
      */
-    public static ContributionsProvider getGitProvider(ProcessRunner runner) {
+    public static ContributionsProvider getContributionsProvider(ProcessRunner runner) {
         return new GitContributionsProvider(new GitLogProvider(runner), new IgnoreCiSkip());
     }
 

--- a/src/main/groovy/org/mockito/release/notes/vcs/Vcs.java
+++ b/src/main/groovy/org/mockito/release/notes/vcs/Vcs.java
@@ -8,9 +8,16 @@ import org.mockito.release.exec.ProcessRunner;
 public class Vcs {
 
     /**
-     * Provides means to get contributions.
+     * Provides means to get contributions. TODO SF rename method
      */
     public static ContributionsProvider getGitProvider(ProcessRunner runner) {
         return new GitContributionsProvider(new GitLogProvider(runner), new IgnoreCiSkip());
+    }
+
+    /**
+     * Provides means to get release dates
+     */
+    public static ReleaseDateProvider getReleaseDateProvider(ProcessRunner runner) {
+        return new DefaultReleaseDateProvider(runner);
     }
 }

--- a/src/test/groovy/org/mockito/release/notes/format/ConciseFormatterTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/format/ConciseFormatterTest.groovy
@@ -7,6 +7,9 @@ import spock.lang.Specification
 
 class ConciseFormatterTest extends Specification {
 
+    /*
+    TODO SF add more useful information to the concise report (like number of contributions)
+    */
     def "formats notes"() {
         def c = Stub(ContributionSet)
         def i1 = [new DefaultImprovement(100, "Fixed issue", "http://issues/100", ["bugfix"], true),

--- a/src/test/groovy/org/mockito/release/notes/format/DefaultFormatterTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/format/DefaultFormatterTest.groovy
@@ -129,7 +129,7 @@ class DefaultFormatterTest extends Specification {
         def is = [new DefaultImprovement(100, "Fix bug x", "http://issues/100", ["bug"], true)]
         def contributions = new DefaultContributionSet({false} as Predicate).add(new GitCommit("a", "a", "m"))
         when: def notes = f.formatVersion(new DefaultReleaseNotesData("2.0.1", date, contributions, is))
-        then: notes == """### 2.0.1 (2017-01-04 23:00 UTC)
+        then: notes == """### 2.0.1 (2017-01-04 23:00)
 
 * Authors: 1
 * Commits: 1

--- a/src/test/groovy/org/mockito/release/notes/internal/DateFormatTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/internal/DateFormatTest.groovy
@@ -1,0 +1,23 @@
+package org.mockito.release.notes.internal
+
+import spock.lang.Specification
+
+class DateFormatTest extends Specification {
+
+    def "parses date"() {
+        def date = DateFormat.parseDate("2017-01-29 08:14:09 -0800")
+
+        expect:
+        //Ensure that the TZ is correct
+        DateFormat.formatDate(date) == "2017-01-29 16:14"
+    }
+
+    def "throws meaningful exception when date cannot be parsed"() {
+        when:
+        DateFormat.parseDate("2017-01- 08:14:09 -0800")
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message.contains("2017-01- 08:14:09 -0800")
+    }
+}

--- a/src/test/groovy/org/mockito/release/notes/vcs/DefaultReleaseDateProviderTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/vcs/DefaultReleaseDateProviderTest.groovy
@@ -1,0 +1,29 @@
+package org.mockito.release.notes.vcs
+
+import org.mockito.release.exec.ProcessRunner
+import org.mockito.release.notes.internal.DateFormat
+import spock.lang.Specification
+
+class DefaultReleaseDateProviderTest extends Specification {
+
+    def runner = Mock(ProcessRunner)
+    def provider = new DefaultReleaseDateProvider(runner)
+
+    def "no versions"() {
+        expect:
+        provider.getReleaseDates([], "v").isEmpty()
+    }
+
+    def "provides release dates"() {
+        runner.run("git", "log", "--pretty=%ad", "--date=iso", "v1.0.0", "-n", "1") >> "\n2017-01-29 08:14:09 -0800\n"
+        runner.run("git", "log", "--pretty=%ad", "--date=iso", "v2.0.0", "-n", "1") >> "\n2017-01-30 10:14:09 -0400\n"
+
+        when:
+        def dates = provider.getReleaseDates(["1.0.0", "2.0.0"], "v")
+
+        then:
+        dates.size() == 2
+        DateFormat.formatDate(dates["1.0.0"]) == "2017-01-29 16:14"
+        DateFormat.formatDate(dates["2.0.0"]) == "2017-01-30 14:14"
+    }
+}


### PR DESCRIPTION
Made progress on issue #9

The concise report now contains release dates based on the date of creation of Git tag.