### PR TITLE
Made repository configurable for generation of release notes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.1.1'
+version = '0.1.2'
 group = 'gradle.plugin.org.mockito'
 
 dependencies {

--- a/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
+++ b/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
@@ -54,7 +54,7 @@ class GitNotesBuilder implements NotesBuilder {
         RevisionProvider revisionProvider = Vcs.getRevisionProvider(processRunner);
         String fromRev = revisionProvider.getRevisionForTagOrRevision(fromRevision);
 
-        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(authToken);
+        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, authToken);
         ContributorsSet contributors = contributorsProvider.mapContributorsToGitHubUser(contributions, fromRev, toRevision);
 
         ImprovementsProvider improvementsProvider = Improvements.getGitHubProvider(repository, authToken);

--- a/src/main/groovy/org/mockito/release/notes/contributors/Contributors.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/Contributors.java
@@ -8,9 +8,10 @@ public class Contributors {
     /**
      * Fetches contribiutors from GitHub. Needs GitHub auth token.
      *
+     * @param repository name of GitHub repository, for example: "mockito/mockito"
      * @param authToken the GitHub auth token
      */
-    public static GitHubContributorsProvider getGitHubContibutorsProvider(String authToken) {
-        return new GitHubContributorsProvider(authToken);
+    public static GitHubContributorsProvider getGitHubContibutorsProvider(String repository, String authToken) {
+        return new GitHubContributorsProvider(repository, authToken);
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsFetcher.java
@@ -15,14 +15,14 @@ public class GitHubContributorsFetcher {
 
     private static final Logger LOG = LoggerFactory.getLogger(GitHubContributorsFetcher.class);
 
-    ContributorsSet fetchContributors(String authToken, Collection<Contribution> contributions, String fromRevision, String toRevision) {
+    ContributorsSet fetchContributors(String repository, String authToken, Collection<Contribution> contributions, String fromRevision, String toRevision) {
         ContributorsSet result = new DefaultContributorsSet();
         LOG.info("Querying GitHub API for commits (for contributors)");
 
         Set<String> authors = getAuthors(contributions);
 
         try {
-            GitHubCommits commits = GitHubCommits.authenticatingWith(authToken)
+            GitHubCommits commits = GitHubCommits.authenticatingWith(repository, authToken)
                     .fromRevision(fromRevision)
                     .toRevision(toRevision)
                     .build();
@@ -140,16 +140,18 @@ public class GitHubContributorsFetcher {
             return lastFetchedPage;
         }
 
-        static GitHubCommitsBuilder authenticatingWith(String authToken) {
-            return new GitHubCommitsBuilder(authToken);
+        static GitHubCommitsBuilder authenticatingWith(String repository, String authToken) {
+            return new GitHubCommitsBuilder(repository, authToken);
         }
 
         private static class GitHubCommitsBuilder {
+            private final String repository;
             private final String authToken;
             private String fromRevision;
             private String toRevision;
 
-            private GitHubCommitsBuilder(String authToken) {
+            private GitHubCommitsBuilder(String repository, String authToken) {
+                this.repository = repository;
                 this.authToken = authToken;
             }
 
@@ -166,7 +168,7 @@ public class GitHubContributorsFetcher {
             GitHubCommits build() {
                 // see API doc: https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
                 String nextPageUrl = String.format("%s%s%s%s",
-                        "https://api.github.com/repos/mockito/mockito/commits",
+                        "https://api.github.com/repos/" + repository + "/commits",
                         "?access_token=" + authToken,
                         max(toRevision),
                         "&page=1");

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsProvider.java
@@ -7,14 +7,16 @@ import org.slf4j.LoggerFactory;
 public class GitHubContributorsProvider implements ContributorsProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(GitHubContributorsProvider.class);
+    private final String repository;
     private final String authToken;
 
-    GitHubContributorsProvider(String authToken) {
+    GitHubContributorsProvider(String repository, String authToken) {
+        this.repository = repository;
         this.authToken = authToken;
     }
 
     public ContributorsSet mapContributorsToGitHubUser(ContributionSet contributions, String fromRevision, String toRevision) {
         LOG.info("Parsing {} commits with {} contributors", contributions.getAllCommits().size(), contributions.getAuthorCount());
-        return new GitHubContributorsFetcher().fetchContributors(authToken, contributions.getContributions(), fromRevision, toRevision);
+        return new GitHubContributorsFetcher().fetchContributors(repository, authToken, contributions.getContributions(), fromRevision, toRevision);
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/generator/ReleaseNotesGenerators.java
+++ b/src/main/groovy/org/mockito/release/notes/generator/ReleaseNotesGenerators.java
@@ -19,7 +19,7 @@ public class ReleaseNotesGenerators {
         ContributionsProvider contributionsProvider = Vcs.getContributionsProvider(processRunner);
         ImprovementsProvider improvementsProvider = Improvements.getGitHubProvider(repository, authToken);
         ReleaseDateProvider releaseDateProvider = Vcs.getReleaseDateProvider(processRunner);
-        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(authToken);
+        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, authToken);
         return new DefaultReleaseNotesGenerator(contributionsProvider, improvementsProvider, releaseDateProvider,
                 contributorsProvider);
     }

--- a/src/test/groovy/org/mockito/release/notes/contributors/GitHubContributorsFetcherTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/GitHubContributorsFetcherTest.groovy
@@ -19,7 +19,7 @@ class GitHubContributorsFetcherTest extends Specification {
                 "2", "szczepiq@gmail.com", "Szczepan Faber", "msg 2")))
 
         when:
-        def contributors = fetcher.fetchContributors(readOnlyToken, contributions, "", "HEAD")
+        def contributors = fetcher.fetchContributors("mockito/mockito", readOnlyToken, contributions, "", "HEAD")
 
         then:
         contributors.findByAuthorName("Continuous Delivery Drone").login == "continuous-delivery-drone"
@@ -32,7 +32,7 @@ class GitHubContributorsFetcherTest extends Specification {
 
     def "dont fetch contributors when empty contributions"() {
         when:
-        def contributors = fetcher.fetchContributors(readOnlyToken, Collections.emptyList(), "", "HEAD")
+        def contributors = fetcher.fetchContributors("mockito/mockito", readOnlyToken, Collections.emptyList(), "", "HEAD")
 
         then:
         contributors.size() == 0


### PR DESCRIPTION
mockito/mockito repository was hardcoded for the release notes generation for the GitHub user mapping logic. This change fixes it.