### PR TITLE
Undesired transitive dependency via json simple #16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,7 @@ dependencies {
     //TODO SF use jcabi to edit issues after the release so that they have the milestone attached
     //compile "com.jcabi:jcabi-github:0.17"
 
-    //Using @jar to avoid transitive dependencies (json-simple declares compile dependency on junit!)
-    compile "com.googlecode.json-simple:json-simple:1.1.1@jar"
+    compile "com.github.cliftonlabs:json-simple:2.1.2"
 
     testCompile("org.spockframework:spock-core:0.7-groovy-2.0") {
         exclude module: "groovy-all"

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubCommitsJSON.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubCommitsJSON.java
@@ -1,19 +1,19 @@
 package org.mockito.release.notes.contributors;
 
-import org.json.simple.JSONObject;
+import org.json.simple.JsonObject;
 import org.mockito.release.notes.model.Contributor;
 
 import java.util.Map;
 
 /**
- * Provides means to parse JSONObjects returned from calling GitHub API.
+ * Provides means to parse JsonObjects returned from calling GitHub API.
  */
 public class GitHubCommitsJSON {
 
     /**
-     * Parses GitHub JSONObject in accordance to the API (https://developer.github.com/v3/repos/commits)
+     * Parses GitHub JsonObject in accordance to the API (https://developer.github.com/v3/repos/commits)
      */
-    static Contributor toContributor(JSONObject commit) {
+    static Contributor toContributor(JsonObject commit) {
         try {
             String name = (String) ((Map) ((Map) commit.get("commit")).get("author")).get("name");
             String login = (String) ((Map) commit.get("author")).get("login");
@@ -24,7 +24,7 @@ public class GitHubCommitsJSON {
         }
     }
 
-    public static boolean containsRevision(JSONObject commit, String revision) {
+    public static boolean containsRevision(JsonObject commit, String revision) {
         String sha = (String)commit.get("sha");
         return sha.equals(revision);
     }

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsFetcher.java
@@ -1,6 +1,7 @@
 package org.mockito.release.notes.contributors;
 
-import org.json.simple.JSONObject;
+import org.json.simple.DeserializationException;
+import org.json.simple.JsonObject;
 import org.mockito.release.notes.model.Commit;
 import org.mockito.release.notes.model.Contribution;
 import org.mockito.release.notes.model.Contributor;
@@ -28,7 +29,7 @@ public class GitHubContributorsFetcher {
                     .build();
 
             while(!authors.isEmpty() && commits.hasNextPage()) {
-                List<JSONObject> page = commits.nextPage();
+                List<JsonObject> page = commits.nextPage();
                 result.addAllContributors(extractContributors(page, authors));
             }
             if(!authors.isEmpty()) {
@@ -53,9 +54,9 @@ public class GitHubContributorsFetcher {
         return authors;
     }
 
-    private Set<Contributor> extractContributors(List<JSONObject> commits, Set<String> authors) {
+    private Set<Contributor> extractContributors(List<JsonObject> commits, Set<String> authors) {
         Set<Contributor> result = new HashSet<Contributor>();
-        for (JSONObject commit : commits) {
+        for (JsonObject commit : commits) {
             Contributor contributor = GitHubCommitsJSON.toContributor(commit);
             if(contributor != null) {
                 if (authors.contains(contributor.getName())) {
@@ -112,7 +113,7 @@ public class GitHubContributorsFetcher {
 
         private final String fromRevision;
         private final GitHubFetcher fetcher;
-        private List<JSONObject> lastFetchedPage;
+        private List<JsonObject> lastFetchedPage;
 
         private GitHubCommits(String nextPageUrl, String fromRevision) {
             fetcher = new GitHubFetcher(nextPageUrl);
@@ -123,11 +124,11 @@ public class GitHubContributorsFetcher {
             return !containsRevision(lastFetchedPage, fromRevision) && fetcher.hasNextPage();
         }
 
-        private boolean containsRevision(List<JSONObject> lastFetchedPage, String revision) {
+        private boolean containsRevision(List<JsonObject> lastFetchedPage, String revision) {
             if(lastFetchedPage == null) {
                 return false;
             }
-            for (JSONObject commit : lastFetchedPage) {
+            for (JsonObject commit : lastFetchedPage) {
                 if(GitHubCommitsJSON.containsRevision(commit, revision)) {
                     return true;
                 }
@@ -135,7 +136,7 @@ public class GitHubContributorsFetcher {
             return false;
         }
 
-        List<JSONObject> nextPage() throws IOException {
+        List<JsonObject> nextPage() throws IOException, DeserializationException {
             lastFetchedPage = fetcher.nextPage();
             return lastFetchedPage;
         }

--- a/src/main/groovy/org/mockito/release/notes/improvements/GitHubImprovementsJSON.java
+++ b/src/main/groovy/org/mockito/release/notes/improvements/GitHubImprovementsJSON.java
@@ -1,37 +1,38 @@
 package org.mockito.release.notes.improvements;
 
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
+import org.json.simple.JsonArray;
+import org.json.simple.JsonObject;
 import org.mockito.release.notes.internal.DefaultImprovement;
 import org.mockito.release.notes.model.Improvement;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
- * Provides means to parse JSONObjects returned from calling GitHub API.
+ * Provides means to parse JsonObjects returned from calling GitHub API.
  */
 class GitHubImprovementsJSON {
 
     /**
-     * Parses GitHub JSONObject in accordance to the API (https://developer.github.com/v3/issues/)
+     * Parses GitHub JsonObject in accordance to the API (https://developer.github.com/v3/issues/)
      */
-    static Improvement toImprovement(JSONObject issue) {
-        Long id = (Long) issue.get("number");
+    static Improvement toImprovement(JsonObject issue) {
+        BigDecimal id = (BigDecimal) issue.get("number");
         String issueUrl = (String) issue.get("html_url");
         String title = (String) issue.get("title");
         boolean isPullRequest = issue.get("pull_request") != null;
         Collection<String> labels = extractLabels(issue);
 
-        return new DefaultImprovement(id, title, issueUrl, labels, isPullRequest);
+        return new DefaultImprovement(id.longValue(), title, issueUrl, labels, isPullRequest);
     }
 
-    private static Collection<String> extractLabels(JSONObject issue) {
+    private static Collection<String> extractLabels(JsonObject issue) {
         Set<String> out = new LinkedHashSet<String>();
-        JSONArray labels = (JSONArray) issue.get("labels");
+        JsonArray labels = (JsonArray) issue.get("labels");
         for (Object o : labels.toArray()) {
-            JSONObject label = (JSONObject) o;
+            JsonObject label = (JsonObject) o;
             out.add((String) label.get("name"));
         }
         return out;

--- a/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
@@ -41,9 +41,7 @@ class GitHubTicketFetcher {
                         page, onlyPullRequests));
             }
         } catch (Exception e) {
-            String message = "Problems fetching " + ticketIds.size() + " tickets from GitHub";
-            LOG.info(message, e);
-            throw new RuntimeException(message, e);
+            throw new RuntimeException("Problems fetching " + ticketIds.size() + " tickets from GitHub", e);
         }
         return out;
     }

--- a/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
@@ -1,12 +1,14 @@
 package org.mockito.release.notes.improvements;
 
-import org.json.simple.JSONObject;
+import org.json.simple.DeserializationException;
+import org.json.simple.JsonObject;
 import org.mockito.release.notes.model.Improvement;
 import org.mockito.release.notes.util.GitHubFetcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.*;
 
 class GitHubTicketFetcher {
@@ -32,24 +34,26 @@ class GitHubTicketFetcher {
                     .browse();
 
             while (!tickets.isEmpty() && issues.hasNextPage()) {
-                List<JSONObject> page = issues.nextPage();
+                List<JsonObject> page = issues.nextPage();
 
                 out.addAll(extractImprovements(
                         dropTicketsAboveMaxInPage(tickets, page),
                         page, onlyPullRequests));
             }
         } catch (Exception e) {
-            throw new RuntimeException("Problems fetching " + ticketIds.size() + " from GitHub", e);
+            String message = "Problems fetching " + ticketIds.size() + " tickets from GitHub";
+            LOG.info(message, e);
+            throw new RuntimeException(message, e);
         }
         return out;
     }
 
-    private Queue<Long> dropTicketsAboveMaxInPage(Queue<Long> tickets, List<JSONObject> page) {
+    private Queue<Long> dropTicketsAboveMaxInPage(Queue<Long> tickets, List<JsonObject> page) {
         if (page.isEmpty()) {
             return tickets;
         }
-        Long highestId = (Long) page.get(0).get("number");
-        while (!tickets.isEmpty() && tickets.peek() > highestId) {
+        BigDecimal highestId = (BigDecimal) page.get(0).get("number");
+        while (!tickets.isEmpty() && tickets.peek() > highestId.longValue()) {
             tickets.poll();
         }
         return tickets;
@@ -66,14 +70,14 @@ class GitHubTicketFetcher {
         return longs;
     }
 
-    private static List<Improvement> extractImprovements(Collection<Long> tickets, List<JSONObject> issues,
+    private static List<Improvement> extractImprovements(Collection<Long> tickets, List<JsonObject> issues,
                                                          boolean onlyPullRequests) {
         if(tickets.isEmpty()) {
             return Collections.emptyList();
         }
 
         ArrayList<Improvement> pagedImprovements = new ArrayList<Improvement>();
-        for (JSONObject issue : issues) {
+        for (JsonObject issue : issues) {
             Improvement i = GitHubImprovementsJSON.toImprovement(issue);
             if (tickets.remove(i.getId())) {
                 if (!onlyPullRequests || i.isPullRequest()) {
@@ -100,7 +104,7 @@ class GitHubTicketFetcher {
             return fetcher.hasNextPage();
         }
 
-        List<JSONObject> nextPage() throws IOException {
+        List<JsonObject> nextPage() throws IOException, DeserializationException {
             return fetcher.nextPage();
         }
 

--- a/src/main/groovy/org/mockito/release/notes/util/GitHubFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/util/GitHubFetcher.java
@@ -1,7 +1,8 @@
 package org.mockito.release.notes.util;
 
-import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
+import org.json.simple.DeserializationException;
+import org.json.simple.JsonObject;
+import org.json.simple.Jsoner;
 import org.mockito.release.notes.internal.DateFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +39,7 @@ public class GitHubFetcher {
         return !RELATIVE_LINK_NOT_FOUND.equals(nextPageUrl);
     }
 
-    public List<JSONObject> nextPage() throws IOException {
+    public List<JsonObject> nextPage() throws IOException, DeserializationException {
         if(RELATIVE_LINK_NOT_FOUND.equals(nextPageUrl)) {
             throw new IllegalStateException("GitHub API no more issues to fetch");
         }
@@ -69,13 +70,13 @@ public class GitHubFetcher {
         return "N/A";
     }
 
-    private List<JSONObject> parseJsonFrom(URLConnection urlConnection) throws IOException {
+    private List<JsonObject> parseJsonFrom(URLConnection urlConnection) throws IOException, DeserializationException {
         InputStream response = urlConnection.getInputStream();
 
         String content = IOUtil.readFully(response);
         LOG.info("GitHub API responded successfully.");
         @SuppressWarnings("unchecked")
-        List<JSONObject> issues = (List<JSONObject>) JSONValue.parse(content);
+        List<JsonObject> issues = (List<JsonObject>) Jsoner.deserialize(content);
         LOG.info("GitHub API returned {} issues.", issues.size());
         return issues;
     }

--- a/src/test/groovy/org/mockito/release/notes/contributors/GitHubCommitsJSONTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/GitHubCommitsJSONTest.groovy
@@ -1,12 +1,12 @@
 package org.mockito.release.notes.contributors
 
-import org.json.simple.JSONObject
+import org.json.simple.JsonObject
 import spock.lang.Specification
 
 class GitHubCommitsJSONTest extends Specification {
 
     def "parse commits"() {
-        def commit = new JSONObject([commit: [author: [name: "Continuous Delivery Drone"]],
+        def commit = new JsonObject([commit: [author: [name: "Continuous Delivery Drone"]],
                                       author: [login: "continuous-delivery-drone",
                                                html_url: "https://github.com/continuous-delivery-drone"]])
 
@@ -21,7 +21,7 @@ class GitHubCommitsJSONTest extends Specification {
 
     def "return null when author doesn't exit (author deleted GitHub account)"() {
         // example: https://github.com/mockito/mockito/commit/87f3a5ee98fcc7c4b6d6d30aec0a2e64562a36eb accout for Ben Yu doesn't exist anymore
-        def commit = new JSONObject([commit: [author: [name: "Continuous Delivery Drone"]],
+        def commit = new JsonObject([commit: [author: [name: "Continuous Delivery Drone"]],
                                       author: null])
 
         when:
@@ -32,7 +32,7 @@ class GitHubCommitsJSONTest extends Specification {
     }
 
     def "return true when commit contains revision"() {
-        def commit = new JSONObject([sha: '1234'])
+        def commit = new JsonObject([sha: '1234'])
 
         when:
         def result = GitHubCommitsJSON.containsRevision(commit, "1234")
@@ -42,7 +42,7 @@ class GitHubCommitsJSONTest extends Specification {
     }
 
     def "return false when commit NOT contains revision"() {
-        def commit = new JSONObject([sha: '1234'])
+        def commit = new JsonObject([sha: '1234'])
 
         when:
         def result = GitHubCommitsJSON.containsRevision(commit, "abc")

--- a/src/test/groovy/org/mockito/release/notes/improvements/GitHubImprovementsJSONTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/improvements/GitHubImprovementsJSONTest.groovy
@@ -1,16 +1,16 @@
 package org.mockito.release.notes.improvements
 
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
+import org.json.simple.JsonArray
+import org.json.simple.JsonObject
 import spock.lang.Specification
 
 class GitHubImprovementsJSONTest extends Specification {
 
     def "parses issue"() {
-        def issue = new JSONObject([number: 100L, html_url: "http://issues/100", title: "Some bugfix"])
-        def labels = new JSONArray()
-        labels.add(new JSONObject([name: "bugfix"]))
-        labels.add(new JSONObject([name: "notable"]))
+        def issue = new JsonObject([number: new BigDecimal(100), html_url: "http://issues/100", title: "Some bugfix"])
+        def labels = new JsonArray()
+        labels.add(new JsonObject([name: "bugfix"]))
+        labels.add(new JsonObject([name: "notable"]))
         issue.put("labels", labels)
 
         when:
@@ -25,8 +25,8 @@ class GitHubImprovementsJSONTest extends Specification {
     }
 
     def "parses pull request without labels"() {
-        def issue = new JSONObject([number: 100L, html_url: "http://issues/100", title: "Some bugfix", pull_request: [:]])
-        issue.put("labels", new JSONArray())
+        def issue = new JsonObject([number: new BigDecimal(100), html_url: "http://issues/100", title: "Some bugfix", pull_request: [:]])
+        issue.put("labels", new JsonArray())
 
         when:
         def i = GitHubImprovementsJSON.toImprovement(issue)


### PR DESCRIPTION
Migrate from com.googlecode.json-simple:json-simple:1.1.1 to com.github.cliftonlabs:json-simple:2.1.2 to avoid JUnit transitive dependency