### PR TITLE
Improved continuous delivery plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build/
+classes/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.2.0'
+version = '0.2.1'
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'
 

--- a/src/main/groovy/org/mockito/release/gradle/BintrayPlugin.java
+++ b/src/main/groovy/org/mockito/release/gradle/BintrayPlugin.java
@@ -8,4 +8,8 @@ import org.gradle.api.Project;
  */
 public interface BintrayPlugin extends Plugin<Project> {
 
+    /**
+     * Name of the task that is configured by this plugin
+     */
+    String BINTRAY_UPLOAD_TASK = "bintrayUpload";
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultBintrayPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultBintrayPlugin.java
@@ -22,7 +22,6 @@ public class DefaultBintrayPlugin implements BintrayPlugin {
         //TODO since this plugin depends on bintray,
         // we need to either shade bintray plugin or ship this Gradle plugin in a separate jar
         project.getPlugins().apply("com.jfrog.bintray");
-        project.getPlugins().apply("com.jfrog.bintray");
         project.getTasks().getByName("bintrayUpload").doFirst(new Action<Task>() {
             public void execute(Task task) {
                 BintrayUploadTask t = (BintrayUploadTask) task;
@@ -39,12 +38,12 @@ public class DefaultBintrayPlugin implements BintrayPlugin {
         final BintrayExtension bintray = project.getExtensions().getByType(BintrayExtension.class);
         project.afterEvaluate(new Action<Project>() {
             public void execute(Project project) {
-            //afterEvaluate so that we access publications as late as possible
-            // otherwise stuff does not work, for example pom does not have dependencies :)
-            if (project.getPlugins().hasPlugin("maven-publish")) {
-                List<String> publicationNames = GradleDSLHelper.publicationNames(project);
-                bintray.setPublications(publicationNames.toArray(new String[publicationNames.size()]));
-            }
+                //afterEvaluate so that we access publications as late as possible
+                // otherwise stuff does not work, for example pom does not have dependencies :)
+                if (project.getPlugins().hasPlugin("maven-publish")) {
+                    List<String> publicationNames = GradleDSLHelper.publicationNames(project);
+                    bintray.setPublications(publicationNames.toArray(new String[publicationNames.size()]));
+                }
             }
         });
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultContinuousDeliveryPlugin.java
@@ -299,7 +299,7 @@ public class DefaultContinuousDeliveryPlugin implements ContinuousDeliveryPlugin
             List<String> args = new LinkedList<String>(asList(
                     "./gradlew", "bintrayUploadAll",
                     "-Prelease_version=" + v,
-                    "-Pbintray_repo=" + ext.getBintrayNotableRepo(),
+                    "-Prelease_notable=true",
                     "-Pbintray_mavenCentralSync"));
 
             if (dryRun) {

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultContinuousDeliveryPlugin.java
@@ -9,6 +9,7 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Exec;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
+import org.mockito.release.gradle.BintrayPlugin;
 import org.mockito.release.gradle.ContinuousDeliveryPlugin;
 import org.mockito.release.internal.gradle.util.CommonSettings;
 import org.mockito.release.internal.gradle.util.ExtContainer;
@@ -102,9 +103,19 @@ public class DefaultContinuousDeliveryPlugin implements ContinuousDeliveryPlugin
             }
         });
 
-        CommonSettings.task(project, "bintrayUploadAll", new Action<Task>() {
+        final Task bintrayUploadAll = CommonSettings.task(project, "bintrayUploadAll", new Action<Task>() {
             public void execute(Task t) {
                 t.setDescription("Depends on all 'bintrayUpload' tasks from all Gradle projects.");
+            }
+        });
+
+        project.allprojects(new Action<Project>() {
+            public void execute(Project project) {
+                project.getPlugins().withType(BintrayPlugin.class, new Action<BintrayPlugin>() {
+                    public void execute(BintrayPlugin bintrayPlugin) {
+                        bintrayUploadAll.dependsOn(BintrayPlugin.BINTRAY_UPLOAD_TASK);
+                    }
+                });
             }
         });
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultReleaseNotesPlugin.java
@@ -7,6 +7,9 @@ import org.mockito.release.gradle.ReleaseNotesPlugin;
 import org.mockito.release.gradle.ReleaseToolsProperties;
 import org.mockito.release.internal.gradle.util.ExtContainer;
 
+import java.io.File;
+
+import static java.util.Arrays.asList;
 import static org.mockito.release.internal.gradle.util.CommonSettings.TASK_GROUP;
 
 /**
@@ -52,12 +55,43 @@ public class DefaultReleaseNotesPlugin implements ReleaseNotesPlugin {
                 });
             }
         });
+
+        project.getTasks().create("notableReleaseNotes", NotableReleaseNotesGeneratorTask.class,
+                new Action<NotableReleaseNotesGeneratorTask>() {
+            public void execute(NotableReleaseNotesGeneratorTask task) {
+                final NotableReleaseNotesGeneratorTask.NotesGeneration gen = task.getNotesGeneration();
+
+                //TODO hardcoded
+                gen.setGitHubLabels(asList("noteworthy"));
+                gen.setDetailedReleaseNotesLink("https://github.com/mockito/mockito-release-tools-example/blob/master/docs/release-notes.md");
+                gen.setGitWorkingDir(project.getRootDir());
+                gen.setIntroductionText("Notable release notes:\n\n");
+                gen.setOnlyPullRequests(true);
+                gen.setOutputFile(new File(project.getRootDir(), "docs/notable-versions.md"));
+                gen.setTagPrefix("v");
+                gen.setVcsCommitsLinkTemplate("https://github.com/mockito/mockito-release-tools-example/compare/{0}...{1}");
+                gen.setTargetVersions(asList("0.10.0", "0.9.0", "0.8.0", "0.7.0"));
+
+                task.doFirst(new Action<Task>() {
+                    public void execute(Task task) {
+                        //lazily configure to give the user chance to specify those settings in build.gradle file
+                        ExtContainer ext = new ExtContainer(project);
+                        if (gen.getGitHubReadOnlyAuthToken() == null) {
+                            gen.setGitHubReadOnlyAuthToken(ext.getGitHubReadOnlyAuthToken());
+                        }
+                        if (gen.getGitHubRepository() == null) {
+                            gen.setGitHubRepository(ext.getGitHubRepository());
+                        }
+                    }
+                });
+            }
+        });
     }
 
     private static void configureNotes(DefaultReleaseNotesExtension notes, Project project) {
         ExtContainer ext = new ExtContainer(project);
         notes.setGitHubLabelMapping(ext.getMap(ReleaseToolsProperties.releaseNotes_labelMapping));
-        notes.setGitHubReadOnlyAuthToken(ext.getString(ReleaseToolsProperties.gh_readOnlyAuthToken));
+        notes.setGitHubReadOnlyAuthToken(ext.getGitHubReadOnlyAuthToken());
         notes.setGitHubRepository(ext.getString(ReleaseToolsProperties.gh_repository));
         notes.setReleaseNotesFile(project.file(ext.getReleaseNotesFile()));
         notes.assertConfigured();

--- a/src/main/groovy/org/mockito/release/internal/gradle/NotableReleaseNotesGeneratorTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/NotableReleaseNotesGeneratorTask.java
@@ -13,25 +13,123 @@ import java.util.Collection;
 
 public class NotableReleaseNotesGeneratorTask extends DefaultTask {
 
-    private File gitWorkingDir;
-    private String gitHubRepository;
-    private String gitHubAuthToken;
-    private Collection<String> targetVersions;
-    private String tagPrefix;
-    private Collection<String> gitHubLabels;
-    private File outputFile;
-    private boolean onlyPullRequests;
-    private String introductionText;
-    private String detailedReleaseNotesLink;
-    private String vcsCommitsLinkTemplate;
+    //TODO documentation
+    private final NotesGeneration notesGeneration = new NotesGeneration();
+
+    public NotesGeneration getNotesGeneration() {
+        return notesGeneration;
+    }
 
     @TaskAction public void generateReleaseNotes() {
+        ReleaseNotesGenerator generator = ReleaseNotesGenerators.releaseNotesGenerator(
+                notesGeneration.gitWorkingDir, notesGeneration.gitHubRepository, notesGeneration.gitHubReadOnlyAuthToken);
+        Collection<ReleaseNotesData> releaseNotes = generator.generateReleaseNotesData(
+                notesGeneration.targetVersions, notesGeneration.tagPrefix, notesGeneration.gitHubLabels, notesGeneration.onlyPullRequests);
+        String notes = ReleaseNotesFormatters.notableFormatter(
+                notesGeneration.introductionText, notesGeneration.detailedReleaseNotesLink, notesGeneration.vcsCommitsLinkTemplate)
+                .formatReleaseNotes(releaseNotes);
+        IOUtil.writeFile(notesGeneration.outputFile, notes);
+    }
 
-        //TODO SF this task is not functioning, I'm using it only to model the public API of interfaces I need.
+    public class NotesGeneration {
+        private File gitWorkingDir;
+        private String gitHubRepository;
+        private String gitHubReadOnlyAuthToken;
+        private Collection<String> targetVersions;
+        private String tagPrefix;
+        private Collection<String> gitHubLabels;
+        private File outputFile;
+        private boolean onlyPullRequests;
+        private String introductionText;
+        private String detailedReleaseNotesLink;
+        private String vcsCommitsLinkTemplate;
 
-        ReleaseNotesGenerator generator = ReleaseNotesGenerators.releaseNotesGenerator(gitWorkingDir, gitHubRepository, gitHubAuthToken);
-        Collection<ReleaseNotesData> releaseNotes = generator.generateReleaseNotesData(targetVersions, tagPrefix, gitHubLabels, onlyPullRequests);
-        String notes = ReleaseNotesFormatters.notableFormatter(introductionText, detailedReleaseNotesLink, vcsCommitsLinkTemplate).formatReleaseNotes(releaseNotes);
-        IOUtil.writeFile(outputFile, notes);
+        public File getGitWorkingDir() {
+            return gitWorkingDir;
+        }
+
+        public void setGitWorkingDir(File gitWorkingDir) {
+            this.gitWorkingDir = gitWorkingDir;
+        }
+
+        public String getGitHubRepository() {
+            return gitHubRepository;
+        }
+
+        public void setGitHubRepository(String gitHubRepository) {
+            this.gitHubRepository = gitHubRepository;
+        }
+
+        public String getGitHubReadOnlyAuthToken() {
+            return gitHubReadOnlyAuthToken;
+        }
+
+        public void setGitHubReadOnlyAuthToken(String gitHubReadOnlyAuthToken) {
+            this.gitHubReadOnlyAuthToken = gitHubReadOnlyAuthToken;
+        }
+
+        public Collection<String> getTargetVersions() {
+            return targetVersions;
+        }
+
+        public void setTargetVersions(Collection<String> targetVersions) {
+            this.targetVersions = targetVersions;
+        }
+
+        public String getTagPrefix() {
+            return tagPrefix;
+        }
+
+        public void setTagPrefix(String tagPrefix) {
+            this.tagPrefix = tagPrefix;
+        }
+
+        public Collection<String> getGitHubLabels() {
+            return gitHubLabels;
+        }
+
+        public void setGitHubLabels(Collection<String> gitHubLabels) {
+            this.gitHubLabels = gitHubLabels;
+        }
+
+        public File getOutputFile() {
+            return outputFile;
+        }
+
+        public void setOutputFile(File outputFile) {
+            this.outputFile = outputFile;
+        }
+
+        public boolean isOnlyPullRequests() {
+            return onlyPullRequests;
+        }
+
+        public void setOnlyPullRequests(boolean onlyPullRequests) {
+            this.onlyPullRequests = onlyPullRequests;
+        }
+
+        public String getIntroductionText() {
+            return introductionText;
+        }
+
+        public void setIntroductionText(String introductionText) {
+            this.introductionText = introductionText;
+        }
+
+        public String getDetailedReleaseNotesLink() {
+            return detailedReleaseNotesLink;
+        }
+
+        public void setDetailedReleaseNotesLink(String detailedReleaseNotesLink) {
+            this.detailedReleaseNotesLink = detailedReleaseNotesLink;
+        }
+
+        public String getVcsCommitsLinkTemplate() {
+            return vcsCommitsLinkTemplate;
+        }
+
+        public void setVcsCommitsLinkTemplate(String vcsCommitsLinkTemplate) {
+            this.vcsCommitsLinkTemplate = vcsCommitsLinkTemplate;
+        }
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/ExtContainer.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/ExtContainer.java
@@ -152,4 +152,11 @@ public class ExtContainer {
     public String getBintrayNotableRepo() {
         return getString("bintray_notableRepo");
     }
+
+    /**
+     * GitHub read only auth token
+     */
+    public String getGitHubReadOnlyAuthToken() {
+        return getString(ReleaseToolsProperties.gh_readOnlyAuthToken);
+    }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/ExtContainer.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/ExtContainer.java
@@ -59,9 +59,13 @@ public class ExtContainer {
      * Bintray repo name for upload
      */
     public String getBintrayRepo() {
-        return getString("bintray_repo");
+        //TODO document String literal in enum or get rid of the enum. Also applies to all string literals in this class
+        if (ext.has("release_notable") && "true".equals(ext.get("release_notable"))) {
+            return getString("bintray_notableRepo");
+        } else {
+            return getString("bintray_repo");
+        }
     }
-    //TODO document String literal in enum or get rid of the enum. Also applies to all string literals in this class
 
     /**
      * GitHub repository name, for example: "mockito/mockito"

--- a/src/main/groovy/org/mockito/release/notes/generator/DefaultReleaseNotesGenerator.java
+++ b/src/main/groovy/org/mockito/release/notes/generator/DefaultReleaseNotesGenerator.java
@@ -1,5 +1,7 @@
 package org.mockito.release.notes.generator;
 
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.mockito.release.notes.contributors.ContributorsSet;
 import org.mockito.release.notes.contributors.ContributorsProvider;
 import org.mockito.release.notes.improvements.ImprovementsProvider;
@@ -13,6 +15,8 @@ import org.mockito.release.notes.vcs.ReleaseDateProvider;
 import java.util.*;
 
 class DefaultReleaseNotesGenerator implements ReleaseNotesGenerator {
+
+    private final static Logger LOG = Logging.getLogger(DefaultReleaseNotesGenerator.class);
 
     private final ContributionsProvider contributionsProvider;
     private final ImprovementsProvider improvementsProvider;
@@ -31,7 +35,15 @@ class DefaultReleaseNotesGenerator implements ReleaseNotesGenerator {
                                                                  Collection<String> gitHubLabels, boolean onlyPullRequests) {
         List<ReleaseNotesData> out = new LinkedList<ReleaseNotesData>();
 
+        LOG.lifecycle("Generating release notes data for:" +
+            "\n  - target versions: " + targetVersions +
+            "\n  - GitHub labels: " + gitHubLabels +
+            "\n  - only pull requests: " + onlyPullRequests +
+            "\n  - version tag prefix: '" + tagPrefix + "'"
+        );
+
         Map<String, Date> releaseDates = releaseDateProvider.getReleaseDates(targetVersions, tagPrefix);
+        LOG.lifecycle("Retrieved " + releaseDates.size() + " release date(s).");
 
         String to = null;
         for (String v : targetVersions) {
@@ -43,8 +55,15 @@ class DefaultReleaseNotesGenerator implements ReleaseNotesGenerator {
             String toRev = tagPrefix + to;
 
             ContributionSet contributions = contributionsProvider.getContributionsBetween(fromRev, toRev);
+            LOG.lifecycle("Retrieved " + contributions.getContributions().size() + " contribution(s) between " + fromRev + ".." + toRev);
+
             Collection<Improvement> improvements = improvementsProvider.getImprovements(contributions, gitHubLabels, onlyPullRequests);
+            LOG.lifecycle("Retrieved " + improvements.size() + " improvement(s) for tickets: " + contributions.getAllTickets());
+
+            //TODO below is duplicated if the author is the same
+            LOG.lifecycle("Getting contributor details for " + contributions.getAuthorCount() + " author(s).");
             ContributorsSet contributors = contributorsProvider.mapContributorsToGitHubUser(contributions, fromRev, toRev);
+
             out.add(new DefaultReleaseNotesData(to, releaseDates.get(to), contributions, improvements, contributors, fromRev, toRev));
 
             //next version

--- a/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
@@ -150,7 +150,7 @@ class GitHubTicketFetcher {
             GitHubIssues browse() {
                 // see API doc: https://developer.github.com/v3/issues/
                 String nextPageUrl = String.format("%s%s%s%s%s%s%s",
-                        "https://api.github.com/repos/mockito/mockito/issues",
+                        "https://api.github.com/repos/" + repository + "/issues",
                         "?access_token=" + authToken,
                         state == null ? "" : "&state=" + state,
                         filter == null ? "" : "&filter=" + filter,


### PR DESCRIPTION
1. Added initial support for generating notable release notes:
 - hooked up new Gradle task that creates notable release notes
 - work in progress, enough to push

2. Improved the continuous delivery plugin:
 - no need for clients to declare dependencies from 'bintrayUploadAll' task
 - no need for clients to include conditional complexity related to notable releases