### PR TITLE
Deleted incorrectly checked-in files

### DIFF
--- a/classes/production/mockito-release-tools/META-INF/gradle-plugins/org.mockito.release-notes.properties
+++ b/classes/production/mockito-release-tools/META-INF/gradle-plugins/org.mockito.release-notes.properties
@@ -1,1 +1,0 @@
-implementation-class=org.mockito.release.internal.gradle.DefaultReleaseNotesPlugin

--- a/classes/production/mockito-release-tools/META-INF/gradle-plugins/org.mockito.release-tools.versioning.properties
+++ b/classes/production/mockito-release-tools/META-INF/gradle-plugins/org.mockito.release-tools.versioning.properties
@@ -1,1 +1,0 @@
-implementation-class=org.mockito.release.internal.gradle.DefaultVersioningPlugin

--- a/classes/production/mockito-release-tools/META-INF/gradle-plugins/org.mockito.release-workflow.properties
+++ b/classes/production/mockito-release-tools/META-INF/gradle-plugins/org.mockito.release-workflow.properties
@@ -1,1 +1,0 @@
-implementation-class=org.mockito.workflow.gradle.internal.ReleaseWorkflowPlugin


### PR DESCRIPTION
We should not check-in anything in the 'classes' or 'build' directories because it is intended for stuff that gets built by Gradle or IDEA during the build / development in IDEA.