### PR TITLE
Started implementing notable releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.2.1'
+version = '0.2.2'
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'
 

--- a/src/main/groovy/org/mockito/release/gradle/BumpVersionFileTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/BumpVersionFileTask.java
@@ -7,6 +7,8 @@ import java.io.File;
 /**
  * Increments version in specified file.
  * The file is expected to have a version property declared, for example: "version=0.0.1"
+ * If {@link #setUpdateNotableVersions(boolean)} is set to true
+ * then the previous version will be added to notable versions, e.g. "notableVersions=1.0.0,1.5.0,2.0.0"
  */
 public interface BumpVersionFileTask extends Task {
 
@@ -20,4 +22,13 @@ public interface BumpVersionFileTask extends Task {
      */
     void setVersionFile(File versionFile);
 
+    /**
+     * See {@link #getUpdateNotableVersions()}
+     */
+    void setUpdateNotableVersions(boolean update);
+
+    /**
+     * Whether to update notable versions by adding previous version to list
+     */
+    boolean getUpdateNotableVersions();
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultBumpVersionFileTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultBumpVersionFileTask.java
@@ -6,7 +6,9 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.mockito.release.gradle.BumpVersionFileTask;
+import org.mockito.release.internal.gradle.util.StringUtil;
 import org.mockito.release.version.Version;
+import org.mockito.release.version.VersionFile;
 
 import java.io.File;
 
@@ -15,6 +17,7 @@ public class DefaultBumpVersionFileTask extends DefaultTask implements BumpVersi
     private final static Logger LOG = Logging.getLogger(DefaultBumpVersionFileTask.class);
 
     private File versionFile;
+    private boolean updateNotableVersions;
 
     @Override
     @InputFile
@@ -27,8 +30,24 @@ public class DefaultBumpVersionFileTask extends DefaultTask implements BumpVersi
         this.versionFile = versionFile;
     }
 
-    @TaskAction public void bumpVersion() {
-        String newVersion = Version.versionFile(versionFile).incrementVersion();
-        LOG.lifecycle("{} - bumped version to {} in file: '{}'.", getPath(), newVersion, getProject().relativePath(versionFile));
+    @Override
+    public void setUpdateNotableVersions(boolean update) {
+        this.updateNotableVersions = update;
+    }
+
+    @Override
+    public boolean getUpdateNotableVersions() {
+        return updateNotableVersions;
+    }
+
+    @TaskAction public void bumpVersionFile() {
+        VersionFile versionFile = Version.versionFile(this.versionFile);
+        String newVersion = versionFile.bumpVersion(updateNotableVersions);
+        LOG.lifecycle("{} - updated version file '{}'\n" +
+                "  - new version: {}\n" +
+                "  - notable versions updated: {}\n" +
+                "  - notable versions: {}",
+                getPath(), getProject().relativePath(this.versionFile), newVersion, updateNotableVersions,
+                StringUtil.join(versionFile.getNotableVersions(), ", "));
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultContinuousDeliveryPlugin.java
@@ -260,7 +260,7 @@ public class DefaultContinuousDeliveryPlugin implements ContinuousDeliveryPlugin
                         //also checking didWork so that we can "-x releaseNeeded" to force the release without criteria check
                         return releaseNeededTask.getDidWork()
                                 //TODO below is awkward, we need a new task type
-                                && true == (Boolean) releaseNeededTask.getExtensions().getExtraProperties().get("needed");
+                                && (Boolean) releaseNeededTask.getExtensions().getExtraProperties().get("needed");
                     }
                 });
                 t.doLast(new Action<Task>() {
@@ -272,7 +272,7 @@ public class DefaultContinuousDeliveryPlugin implements ContinuousDeliveryPlugin
                         //finally, let's make the release!
                         exec(project, "./gradlew", "performRelease");
                         //perform notable release if needed
-                        performNotableRelease(project, ext, false);
+                        performNotableRelease(project, false);
                     }
                 });
             }
@@ -294,14 +294,14 @@ public class DefaultContinuousDeliveryPlugin implements ContinuousDeliveryPlugin
                 t.setDescription("Tests the notable release, intended to be used locally by engineers");
                 t.doLast(new Action<Task>() {
                     public void execute(Task task) {
-                        performNotableRelease(project, ext, true);
+                        performNotableRelease(project, true);
                     }
                 });
             }
         });
     }
 
-    static void performNotableRelease(Project project, ExtContainer ext, boolean dryRun) {
+    private static void performNotableRelease(Project project, boolean dryRun) {
         String v = project.getVersion().toString();
         if (v.endsWith(".0") || v.endsWith(".0.0")) { //new minor or major version
             LOG.lifecycle("  It looks like we are releasing a new notable version '{}'!\n" +
@@ -325,11 +325,11 @@ public class DefaultContinuousDeliveryPlugin implements ContinuousDeliveryPlugin
         }
     }
 
-    static void performReleaseTest(Project project) {
+    private static void performReleaseTest(Project project) {
         exec(project, "./gradlew", "performRelease", "releaseCleanUp", "-PreleaseDryRun");
     }
 
-    static ExecResult exec(Project project, final String ... commandLine) {
+    private static ExecResult exec(Project project, final String... commandLine) {
         return project.exec(new Action<ExecSpec>() {
             public void execute(ExecSpec e) {
                 e.commandLine(commandLine);

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultVersioningPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultVersioningPlugin.java
@@ -18,10 +18,9 @@ public class DefaultVersioningPlugin implements VersioningPlugin {
     private static Logger LOG = Logging.getLogger(DefaultVersioningPlugin.class);
 
     public void apply(Project project) {
-        File versionFile = project.file("version.properties");
-        final String version;
-
+        final File versionFile = getVersionFile(project);
         ExtraPropertiesExtension ext = project.getExtensions().getExtraProperties();
+        final String version;
         if (ext.has("release_version")) {
             version = ext.get("release_version").toString();
             LOG.lifecycle("  Using version '{}' supplied via 'release_version' project property.", version);
@@ -37,9 +36,17 @@ public class DefaultVersioningPlugin implements VersioningPlugin {
             }
         });
 
-        BumpVersionFileTask task = project.getTasks().create("bumpVersionFile", DefaultBumpVersionFileTask.class);
-        task.setVersionFile(versionFile);
-        task.setDescription("Increments version number in the properties file that contains the version.");
-        task.setGroup(TASK_GROUP);
+        project.getTasks().create("bumpVersionFile", DefaultBumpVersionFileTask.class, new Action<DefaultBumpVersionFileTask>() {
+            public void execute(DefaultBumpVersionFileTask t) {
+                t.setVersionFile(versionFile);
+                t.setDescription("Increments version number in " + versionFile.getName());
+                t.setGroup(TASK_GROUP);
+            }
+        });
+    }
+
+    public static File getVersionFile(Project project) {
+        //TODO should add singleton extension object to root project with version object
+        return new File(project.getRootDir(), "version.properties");
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/ExtContainer.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/ExtContainer.java
@@ -159,4 +159,11 @@ public class ExtContainer {
     public String getGitHubReadOnlyAuthToken() {
         return getString(ReleaseToolsProperties.gh_readOnlyAuthToken);
     }
+
+    /**
+     * Notable release notes file, for example "docs/notable-release-notes.md"
+     */
+    public String getNotableReleaseNotesFile() {
+        return getString("releaseNotes_notableFile");
+    }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/StringUtil.groovy
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/StringUtil.groovy
@@ -13,7 +13,7 @@ class StringUtil {
     /**
      * Classic string join
      */
-    static String join(List<String> collection, String separator) {
+    static String join(Collection<String> collection, String separator) {
         return collection.join(separator)
     }
 }

--- a/src/main/groovy/org/mockito/release/version/VersionFile.java
+++ b/src/main/groovy/org/mockito/release/version/VersionFile.java
@@ -1,18 +1,25 @@
 package org.mockito.release.version;
 
+import java.util.Collection;
+
 /**
  * The file that contains version number
+ * TODO rename to VersionInfo
  */
 public interface VersionFile {
 
     /**
-     * the version number
+     * Version number
      */
     String getVersion();
 
     /**
-     * increments version number in the file and returns incremented value
+     * Increments version number in the backing object (typically a file) and returns incremented value
      */
     String incrementVersion();
 
+    /**
+     * Returns notable versions
+     */
+    Collection<String> getNotableVersions();
 }

--- a/src/main/groovy/org/mockito/release/version/VersionFile.java
+++ b/src/main/groovy/org/mockito/release/version/VersionFile.java
@@ -14,9 +14,11 @@ public interface VersionFile {
     String getVersion();
 
     /**
-     * Increments version number in the backing object (typically a file) and returns incremented value
+     * Increments version number in the backing object (typically a file) and returns incremented value.
+     *
+     * @param updateNotable if true, the previous version will be included in the notable versions, too.
      */
-    String incrementVersion();
+    String bumpVersion(boolean updateNotable);
 
     /**
      * Returns notable versions

--- a/src/test/groovy/org/mockito/release/version/DefaultVersionFileTest.groovy
+++ b/src/test/groovy/org/mockito/release/version/DefaultVersionFileTest.groovy
@@ -56,4 +56,16 @@ x
         then:
         f.text == "foo=bar\nversion=2.0.1\n"
     }
+
+    def "knows notable versions"() {
+        expect:
+        def f = dir.newFile() << "version=1.0\n" + file
+        new DefaultVersionFile(f).notableVersions.toString() == versions.toString()
+
+        where:
+        file                                       | versions
+        "notableVersions= 1.0, 2.0-beta.1, 3.5.6 " | ['1.0', '2.0-beta.1', '3.5.6']
+        "notableVersions="                         | []
+        "foo="                                     | []
+    }
 }

--- a/src/test/groovy/org/mockito/release/version/DefaultVersionFileTest.groovy
+++ b/src/test/groovy/org/mockito/release/version/DefaultVersionFileTest.groovy
@@ -35,7 +35,7 @@ x
 
         when:
         def v = new DefaultVersionFile(f)
-        v.incrementVersion()
+        v.bumpVersion(false)
 
         then:
         f.text == """
@@ -51,7 +51,7 @@ x
         def f = dir.newFile() << "foo=bar\nversion=2.0.0"
 
         when:
-        new DefaultVersionFile(f).incrementVersion()
+        new DefaultVersionFile(f).bumpVersion(false)
 
         then:
         f.text == "foo=bar\nversion=2.0.1\n"
@@ -67,5 +67,37 @@ x
         "notableVersions= 1.0, 2.0-beta.1, 3.5.6 " | ['1.0', '2.0-beta.1', '3.5.6']
         "notableVersions="                         | []
         "foo="                                     | []
+    }
+
+    def "bumps notable version"() {
+        def f = dir.newFile() << """
+version=2.0.0
+notableVersions=1.0.0
+"""
+
+        when:
+        def v = new DefaultVersionFile(f)
+        v.bumpVersion(true)
+
+        then:
+        f.text == """
+version=2.0.1
+notableVersions=1.0.0, 2.0.0
+"""
+        v.notableVersions.toString() == ["1.0.0", "2.0.0"].toString()
+    }
+
+    def "bumps notable version when no prior notable versions"() {
+        def f = dir.newFile() << "version=1.0.0"
+
+        when:
+        def v = new DefaultVersionFile(f)
+        v.bumpVersion(true)
+
+        then:
+        f.text == """version=1.0.1
+notableVersions=1.0.0
+"""
+        v.notableVersions.toString() == ["1.0.0"].toString()
     }
 }


### PR DESCRIPTION
- Added support for keeping the notable versions in the 'version.properties' file.
- For design, see #49
- Tested with unit tests and the example repository
