### PR TITLE
Fixed bug with the order of versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.2.3'
+version = '0.2.4'
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultContinuousDeliveryPlugin.java
@@ -110,6 +110,9 @@ public class DefaultContinuousDeliveryPlugin implements ContinuousDeliveryPlugin
         final Task bintrayUploadAll = CommonSettings.task(project, "bintrayUploadAll", new Action<Task>() {
             public void execute(Task t) {
                 t.setDescription("Depends on all 'bintrayUpload' tasks from all Gradle projects.");
+                //It is safer to run bintray upload after git push
+                //This way, when git push fails we don't publish jars to bintray
+                t.mustRunAfter("gitPush");
             }
         });
 

--- a/src/main/groovy/org/mockito/release/version/DefaultVersionFile.java
+++ b/src/main/groovy/org/mockito/release/version/DefaultVersionFile.java
@@ -13,7 +13,7 @@ import java.util.Properties;
 class DefaultVersionFile implements VersionFile {
 
     private final File versionFile;
-    private final List<String> notableVersions;
+    private final LinkedList<String> notableVersions;
     private String version;
 
     DefaultVersionFile(File versionFile) {
@@ -26,8 +26,8 @@ class DefaultVersionFile implements VersionFile {
         this.notableVersions = parseNotableVersions(properties);
     }
 
-    private List<String> parseNotableVersions(Properties properties) {
-        List<String> result = new LinkedList<String>();
+    private static LinkedList<String> parseNotableVersions(Properties properties) {
+        LinkedList<String> result = new LinkedList<String>();
         String value = properties.getProperty("notableVersions");
         if (value != null) {
             String[] versions = value.split(",");
@@ -59,7 +59,7 @@ class DefaultVersionFile implements VersionFile {
     public String bumpVersion(boolean updateNotable) {
         String content = IOUtil.readFully(versionFile);
         if (updateNotable) {
-            notableVersions.add(version);
+            notableVersions.addFirst(version);
             String asString = "notableVersions=" + StringUtil.join(notableVersions, ", ") + "\n";
             if (notableVersions.size() == 1) {
                 //when no prior notable versions, we just add new entry

--- a/src/test/groovy/org/mockito/release/version/DefaultVersionFileTest.groovy
+++ b/src/test/groovy/org/mockito/release/version/DefaultVersionFileTest.groovy
@@ -82,9 +82,9 @@ notableVersions=1.0.0
         then:
         f.text == """
 version=2.0.1
-notableVersions=1.0.0, 2.0.0
+notableVersions=2.0.0, 1.0.0
 """
-        v.notableVersions.toString() == ["1.0.0", "2.0.0"].toString()
+        v.notableVersions.toString() == ["2.0.0", "1.0.0"].toString()
     }
 
     def "bumps notable version when no prior notable versions"() {


### PR DESCRIPTION
- the latest version is expected first on the list so that release notes generation does the right thing
- improved task ordering rules for safer releases