### PR TITLE
Host of fixes and improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.3.0'
+version = '0.3.5'
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultBaseJavaLibraryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultBaseJavaLibraryPlugin.java
@@ -4,6 +4,8 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.maven.MavenPublication;
@@ -16,6 +18,10 @@ import org.mockito.release.internal.gradle.util.GradleDSLHelper;
  * Please keep documentation up to date at {@link BaseJavaLibraryPlugin}
  */
 public class DefaultBaseJavaLibraryPlugin implements BaseJavaLibraryPlugin {
+
+    private final static Logger LOG = Logging.getLogger(DefaultBaseJavaLibraryPlugin.class);
+
+    final static String PUBLICATION_NAME = "javaLibrary";
 
     public void apply(final Project project) {
         project.getPlugins().apply("java");
@@ -52,14 +58,16 @@ public class DefaultBaseJavaLibraryPlugin implements BaseJavaLibraryPlugin {
 
         GradleDSLHelper.publications(project, new Action<PublicationContainer>() {
             public void execute(PublicationContainer publications) {
-                publications.create("javaLibrary", MavenPublication.class, new Action<MavenPublication>() {
+                MavenPublication p = publications.create(PUBLICATION_NAME, MavenPublication.class, new Action<MavenPublication>() {
                     public void execute(MavenPublication publication) {
                         publication.from(project.getComponents().getByName("java"));
                         publication.artifact(sourcesJar);
                         publication.artifact(javadocJar);
+                        publication.setArtifactId(((Jar) project.getTasks().getByName("jar")).getBaseName());
                         PomCustomizer.customizePom(project, publication);
                     }
                 });
+                LOG.info("{} - configured '{}' publication", project.getPath(), p.getArtifactId());
             }
         });
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultBintrayPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultBintrayPlugin.java
@@ -35,18 +35,7 @@ public class DefaultBintrayPlugin implements BintrayPlugin {
             }
         });
 
-        final BintrayExtension bintray = project.getExtensions().getByType(BintrayExtension.class);
-        project.afterEvaluate(new Action<Project>() {
-            public void execute(Project project) {
-                //afterEvaluate so that we access publications as late as possible
-                // otherwise stuff does not work, for example pom does not have dependencies :)
-                if (project.getPlugins().hasPlugin("maven-publish")) {
-                    List<String> publicationNames = GradleDSLHelper.publicationNames(project);
-                    bintray.setPublications(publicationNames.toArray(new String[publicationNames.size()]));
-                }
-            }
-        });
-
+        BintrayExtension bintray = project.getExtensions().getByType(BintrayExtension.class);
         ExtContainer ext = new ExtContainer(project.getRootProject());
 
         bintray.setPublish(true);

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultJavaLibraryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultJavaLibraryPlugin.java
@@ -1,12 +1,30 @@
 package org.mockito.release.internal.gradle;
 
+import com.jfrog.bintray.gradle.BintrayExtension;
 import org.gradle.api.Project;
 import org.mockito.release.gradle.JavaLibraryPlugin;
+
+import static org.mockito.release.internal.gradle.DefaultBaseJavaLibraryPlugin.PUBLICATION_NAME;
 
 public class DefaultJavaLibraryPlugin implements JavaLibraryPlugin {
 
     public void apply(Project project) {
         project.getPlugins().apply("org.mockito.mockito-release-tools.base-java-library");
         project.getPlugins().apply("org.mockito.mockito-release-tools.bintray");
+
+        if (shouldConfigurePublications(project)) {
+            BintrayExtension bintray = project.getExtensions().getByType(BintrayExtension.class);
+            bintray.setPublications(PUBLICATION_NAME);
+        }
+    }
+
+    private boolean shouldConfigurePublications(Project project) {
+        //Sanity system property. Semi-internal.
+        boolean workaroundTurnedOff = "false".equals(System.getProperty("org.mockito.mockito-release-tools.publications-bug-workaround"));
+        if (workaroundTurnedOff) {
+            return true;
+        }
+        //Workaround for bintray plugin/Gradle bug (https://github.com/bintray/gradle-bintray-plugin/issues/159)
+        return !project.getGradle().getStartParameter().getTaskNames().contains("tasks");
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/GradleDSLHelper.groovy
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/GradleDSLHelper.groovy
@@ -4,9 +4,7 @@ import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.publish.Publication
 import org.gradle.api.publish.PublicationContainer
-import org.gradle.api.publish.PublishingExtension
 
 /**
  * Useful to work around Gradle API that requires the use of Groovy.
@@ -24,13 +22,5 @@ class GradleDSLHelper {
         project.publishing {
             action.execute(publications)
         }
-    }
-
-    /**
-     * Names of all publications found in this project
-     */
-    static List<String> publicationNames(Project project) {
-        PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class)
-        return publishing.getPublications().collect { Publication it -> it.name }
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/util/IOUtil.java
+++ b/src/main/groovy/org/mockito/release/notes/util/IOUtil.java
@@ -57,6 +57,7 @@ public class IOUtil {
     public static void writeFile(File target, String content) {
         PrintWriter p = null;
         try {
+            target.getParentFile().mkdirs();
             p = new PrintWriter(new FileWriter(target));
             p.write(content);
         } catch (Exception e) {

--- a/src/test/groovy/org/mockito/release/notes/util/IOUtilTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/util/IOUtilTest.groovy
@@ -26,7 +26,7 @@ class IOUtilTest extends Specification {
     }
 
     def "writes file"() {
-        def f = tmp.newFile()
+        def f = new File(tmp.root, "x/y/z.txt")
         writeFile(f, "ala\nma")
 
         expect:


### PR DESCRIPTION
 - IO utility fixes
 - removed unnecessarily complicated logic that was collecting all declared publications. Instead, we just set the publication we know about
 - improved the logging of git push so that it's easier to grasp problems. Kept the senstivie GH token away from the log so that it is safe
 - added missing task dependency between git commits and git tag
 - broke the notable release generation. will fix it soon