### PR TITLE
Support for publishing to notable Bintray packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.4.0'
+version = '0.4.1'
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultBintrayPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultBintrayPlugin.java
@@ -10,9 +10,6 @@ import org.gradle.api.logging.Logging;
 import org.mockito.release.gradle.BintrayPlugin;
 import org.mockito.release.internal.gradle.util.EnvVariables;
 import org.mockito.release.internal.gradle.util.ExtContainer;
-import org.mockito.release.internal.gradle.util.GradleDSLHelper;
-
-import java.util.List;
 
 public class DefaultBintrayPlugin implements BintrayPlugin {
 
@@ -48,6 +45,7 @@ public class DefaultBintrayPlugin implements BintrayPlugin {
         pkg.setWebsiteUrl("https://github.com/" + ext.getGitHubRepository());
         pkg.setIssueTrackerUrl("https://github.com/" + ext.getGitHubRepository() + "/issues");
         pkg.setVcsUrl("https://github.com/" + ext.getGitHubRepository() + ".git");
+        pkg.setName(ext.getBintrayPkgName());
 
         pkg.getVersion().setVcsTag("v" + project.getVersion());
         pkg.getVersion().getGpg().setSign(true);

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultReleaseNotesPlugin.java
@@ -6,6 +6,7 @@ import org.gradle.api.Task;
 import org.mockito.release.gradle.ReleaseNotesPlugin;
 import org.mockito.release.gradle.ReleaseToolsProperties;
 import org.mockito.release.internal.gradle.util.ExtContainer;
+import org.mockito.release.internal.gradle.util.SettingsConfigurer;
 
 import java.io.File;
 
@@ -62,9 +63,8 @@ public class DefaultReleaseNotesPlugin implements ReleaseNotesPlugin {
                 final NotesGeneration gen = task.getNotesGeneration();
                 preconfigureNotableNotes(project, gen);
 
-                task.doFirst(new Action<Task>() {
-                    public void execute(Task task) {
-                        //lazily configure to give the user chance to specify those settings in build.gradle file
+                SettingsConfigurer.getConfigurer(project).configureLazily(task, new Runnable() {
+                    public void run() {
                         configureNotableNotes(project, gen);
                     }
                 });
@@ -79,9 +79,8 @@ public class DefaultReleaseNotesPlugin implements ReleaseNotesPlugin {
 
                 task.dependsOn("fetchNotableReleaseNotes");
 
-                task.doFirst(new Action<Task>() {
-                    public void execute(Task task) {
-                        //lazily configure to give the user chance to specify those settings in build.gradle file
+                SettingsConfigurer.getConfigurer(project).configureLazily(task, new Runnable() {
+                    public void run() {
                         configureNotableNotes(project, gen);
                     }
                 });

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/EnvVariables.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/EnvVariables.java
@@ -6,6 +6,7 @@ public class EnvVariables {
      * Provides env variables and validates presence.
      *
      * TODO merge somehow with ExtContainer, have one class that has all settings.
+     * TODO validate presence of every required env variable that will be needed during the build before the build starts
      */
     public static String getEnv(String envName) {
         String value = System.getenv(envName);

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/ExtContainer.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/ExtContainer.java
@@ -58,11 +58,14 @@ public class ExtContainer {
      */
     public String getBintrayRepo() {
         //TODO document String literal in enum or get rid of the enum. Also applies to all string literals in this class
-        if (ext.has("release_notable") && "true".equals(ext.get("release_notable"))) {
-            return getString("bintray_notableRepo");
-        } else {
-            return getString("bintray_repo");
+        return getMaybeNotable("bintray_repo", "bintray_notableRepo");
+    }
+
+    private String getMaybeNotable(String key, String notableKey) {
+        if (ext.has("release_notable") && "true".equals(ext.get("release_notable")) && ext.has(notableKey)) {
+            return getString(notableKey);
         }
+        return getString(key);
     }
 
     /**
@@ -123,6 +126,7 @@ public class ExtContainer {
      * Returns the branch to work on by checking the env variable 'TRAVIS_BRANCH'
      */
     public String getCurrentBranch() {
+        //TODO if not set, we should just call 'git branch' and parse the output. This will make things easier for local testing.
         return EnvVariables.getEnv("TRAVIS_BRANCH");
     }
 
@@ -148,13 +152,6 @@ public class ExtContainer {
     }
 
     /**
-     * Name of Bintray repo for notable releases, for example "mockito-notable"
-     */
-    public String getBintrayNotableRepo() {
-        return getString("bintray_notableRepo");
-    }
-
-    /**
      * GitHub read only auth token
      */
     public String getGitHubReadOnlyAuthToken() {
@@ -166,5 +163,12 @@ public class ExtContainer {
      */
     public String getNotableReleaseNotesFile() {
         return getString("releaseNotes_notableFile");
+    }
+
+    /**
+     * Bintray package name,
+     */
+    public String getBintrayPkgName() {
+        return getMaybeNotable("bintray_pkg", "bintray_notablePkg");
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/PomCustomizer.groovy
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/PomCustomizer.groovy
@@ -39,7 +39,7 @@ class PomCustomizer {
         //TODO relies on ext properties set on the root project. Seems not right
         def ext = new ExtContainer(project.rootProject)
         publication.pom.withXml {
-            LOG.lifecycle("""  Customizing pom for publication '$publication.name' in project '$project.path'
+            LOG.info("""  Customizing pom for publication '$publication.name' in project '$project.path'
     - Module name (project.archivesBaseName): $project.archivesBaseName
     - Description (project.description): $project.description
     - GitHub repository (project.rootProject.ext.gh_repository): ${ext.getString(ReleaseToolsProperties.gh_repository)}

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/SettingsConfigurer.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/SettingsConfigurer.java
@@ -1,0 +1,52 @@
+package org.mockito.release.internal.gradle.util;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.execution.TaskExecutionGraph;
+import org.gradle.api.execution.TaskExecutionGraphListener;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Offers means to lazily configure Gradle tasks, only when the tasks are in the task graph.
+ * This way, we identify missing settings before tasks are executed.
+ * This is important, because when tasks are executed they can do stuff that is hard to reverse.
+ * So we want to do all the validation beforehand.
+ */
+public class SettingsConfigurer implements TaskExecutionGraphListener {
+
+    private Map<Task, Runnable> actions = new LinkedHashMap<Task, Runnable>();
+
+    public void graphPopulated(TaskExecutionGraph graph) {
+        for (Map.Entry<Task, Runnable> e : actions.entrySet()) {
+            if (graph.hasTask(e.getKey())) {
+                e.getValue().run();
+            }
+        }
+    }
+
+    /**
+     * Gets the configurer for the project. Configurer is a singleton hooked up to the root project.
+     */
+    public static SettingsConfigurer getConfigurer(Project project) {
+        Project rootProject = project.getRootProject();
+        //single configurer for the entire build, hooked up to the root project, for simplicity and speed
+        //we don't want too many listeners that introduce blocking callbacks to Gradle internals
+
+        SettingsConfigurer validator = rootProject.getExtensions().findByType(SettingsConfigurer.class);
+        if (validator == null) {
+            validator = new SettingsConfigurer();
+            rootProject.getExtensions().add(SettingsConfigurer.class.getName(), validator);
+            rootProject.getGradle().addListener(validator);
+        }
+        return validator;
+    }
+
+    /**
+     * Lazily configures given task, only when the task is included in the task graph
+     */
+    public void configureLazily(Task task, Runnable action) {
+        actions.put(task, action);
+    }
+}

--- a/src/test/groovy/org/mockito/release/internal/gradle/DefaultBintrayPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/DefaultBintrayPluginTest.groovy
@@ -9,6 +9,7 @@ class DefaultBintrayPluginTest extends Specification {
 
     def "applies"() {
         project.ext.bintray_repo = "my-repo"
+        project.ext.bintray_pkg = "my-pkg"
         project.ext.gh_repository = "mockito/mockito"
 
         expect:

--- a/src/test/groovy/org/mockito/release/internal/gradle/DefaultJavaLibraryPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/DefaultJavaLibraryPluginTest.groovy
@@ -10,6 +10,7 @@ class DefaultJavaLibraryPluginTest extends Specification {
     def "applies"() {
         project.ext.bintray_repo = "my-repo"
         project.ext.gh_repository = "mockito/mockito"
+        project.ext.bintray_pkg = "my-pkg"
 
         expect:
         project.plugins.apply("org.mockito.mockito-release-tools.java-library")

--- a/src/test/groovy/org/mockito/release/internal/gradle/util/ExtContainerTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/util/ExtContainerTest.groovy
@@ -1,0 +1,40 @@
+package org.mockito.release.internal.gradle.util
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class ExtContainerTest extends Specification {
+
+    def project = new ProjectBuilder().build()
+    def ext = new ExtContainer(project)
+
+    def "provides bintray repo"() {
+        when: project.ext.'bintray_repo' = 'all'
+        then: ext.bintrayRepo == 'all'
+
+        when: project.ext.'bintray_notableRepo' = 'notable'
+        then: ext.bintrayRepo == 'all'
+
+        when: project.ext.'release_notable' = 'true'
+        then: ext.bintrayRepo == 'notable'
+    }
+
+    def "provides default notable repo"() {
+        when:
+        project.ext.'bintray_repo' = 'repo'
+        project.ext.'release_notable' = 'true'
+
+        then: ext.bintrayRepo == 'repo'
+    }
+
+    def "provides pkg"() {
+        when: project.ext.'bintray_pkg' = 'all'
+        then: ext.bintrayPkgName == 'all'
+
+        when:
+        project.ext.'bintray_notablePkg' = 'notable'
+        project.ext.'release_notable' = 'true'
+
+        then: ext.bintrayPkgName == 'notable'
+    }
+}

--- a/src/test/groovy/org/mockito/release/internal/gradle/util/SettingsConfigurerTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/util/SettingsConfigurerTest.groovy
@@ -1,0 +1,36 @@
+package org.mockito.release.internal.gradle.util
+
+import org.gradle.api.execution.TaskExecutionGraph
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+import static org.mockito.release.internal.gradle.util.SettingsConfigurer.getConfigurer
+
+class SettingsConfigurerTest extends Specification {
+
+    def project1 = new ProjectBuilder().build()
+    def project2 = new ProjectBuilder().withParent(project1).build()
+
+    def "there is only one configurer"() {
+        expect:
+        getConfigurer(project1) == getConfigurer(project2)
+    }
+
+    def "configures tasks lazily"() {
+        given:
+        def foo = project1.task("foo")
+        def bar = project1.task("bar")
+        getConfigurer(project1).configureLazily(foo, { foo.description = "foo task" } as Runnable)
+        getConfigurer(project1).configureLazily(bar, { bar.description = "bar task" } as Runnable)
+
+        when:
+        getConfigurer(project1).graphPopulated(Stub(TaskExecutionGraph) {
+            hasTask(foo) >> true
+            hasTask(bar) >> false
+        })
+
+        then:
+        foo.description == "foo task"
+        bar.description == null //configuration not triggered because task was not in graph
+    }
+}


### PR DESCRIPTION
Best to review commit-by-commit

- Publishing 'notable' and 'regular' versions to separate Bintray packages maps better to Bintray repo/package model.
- Introduced new object that makes it easier to configure tasks lazily. Previously, we've been using 'doFirst' for this. However, 'doFirst' gives late feedback in case some necessary setting is not configured. We should replace all usages of doFirst() for configuration with this new API
- Some minor tweaks

Tested with example repo (pull request: TODO). Output:

**./gradlew testRelease**
```
~/mockito/example-release$ ./gradlew testRelease
  Using version '0.13.6' from 'version.properties' file.
:testRelease
  Running:
    ./gradlew performRelease releaseCleanUp -PreleaseDryRun
Starting a Gradle Daemon, 1 busy and 3 stopped Daemons could not be reused, use --status for details
  Using version '0.13.6' from 'version.properties' file.
:bumpVersionFile
:bumpVersionFile - updated version file 'version.properties'
  - new version: 0.13.7
  - notable versions updated: false
  - notable versions: 0.10.0, 0.7.1, 0.0.1
:gitAddBumpVersion
  Running:
    git add version.properties
:fetchNotableReleaseNotes UP-TO-DATE
:updateNotableReleaseNotes
:updateReleaseNotes
Building new release notes based on /Users/sfaber/mockito/example-release/docs/release-notes.md
Building notes for revisions: v0.13.5 -> HEAD
Successfully updated release notes!
:gitAddReleaseNotes
  Running:
    git add docs/release-notes.md docs/notable-release-notes.md
:gitCommit
  Running:
    git commit --author Mockito Release Tools <<mockito.release.tools@gmail.com>> -m Bumped version and updated release notes [ci skip]
[sf 3f5f5b6] Bumped version and updated release notes [ci skip]
 Author: Mockito Release Tools <mockito.release.tools@gmail.com>
 3 files changed, 10 insertions(+), 3 deletions(-)
:gitTag
  Running:
    git tag -a v0.13.6 -m Created new tag v0.13.6 [ci skip]
:gitPush
  'git push' arguments:
    git push https://szczepiq:[GH_WRITE_TOKEN]@github.com/mockito/mockito-release-tools-example.git sf v0.13.6 -q --dry-run
:api:generatePomFileForJavaLibraryPublication
  Customizing pom for publication 'javaLibrary' in project ':api'
    - Module name (project.archivesBaseName): api
    - Description (project.description): null
    - GitHub repository (project.rootProject.ext.gh_repository): mockito/mockito-release-tools-example
    - Developers (project.rootProject.ext.pom_developers): szczepiq:Szczepan Faber
    - Contributors (project.rootProject.ext.pom_contributors): mstachniuk:Marcin Stachniuk, wwilk:Wojtek Wilk
:api:compileJava UP-TO-DATE
:api:processResources NO-SOURCE
:api:classes UP-TO-DATE
:api:jar UP-TO-DATE
:api:javadoc UP-TO-DATE
:api:javadocJar UP-TO-DATE
:api:sourcesJar UP-TO-DATE
:api:publishJavaLibraryPublicationToMavenLocal
:api:bintrayUpload
:api:bintrayUpload - publishing to Bintray
  - dry run: true
  - repository: examples
  - version: 0.13.6
  - Maven Central sync: true
:impl:generatePomFileForJavaLibraryPublication
  Customizing pom for publication 'javaLibrary' in project ':impl'
    - Module name (project.archivesBaseName): impl
    - Description (project.description): null
    - GitHub repository (project.rootProject.ext.gh_repository): mockito/mockito-release-tools-example
    - Developers (project.rootProject.ext.pom_developers): szczepiq:Szczepan Faber
    - Contributors (project.rootProject.ext.pom_contributors): mstachniuk:Marcin Stachniuk, wwilk:Wojtek Wilk
:impl:compileJava UP-TO-DATE
:impl:processResources NO-SOURCE
:impl:classes UP-TO-DATE
:impl:jar UP-TO-DATE
:impl:javadoc UP-TO-DATE
:impl:javadocJar UP-TO-DATE
:impl:sourcesJar UP-TO-DATE
:impl:publishJavaLibraryPublicationToMavenLocal
:impl:bintrayUpload
:impl:bintrayUpload - publishing to Bintray
  - dry run: true
  - repository: examples
  - version: 0.13.6
  - Maven Central sync: true
:bintrayUploadAll
:performRelease
:releaseCleanUp UP-TO-DATE
:gitCommitCleanUp
  Running:
    git reset --hard HEAD~
HEAD is now at 00fa117 Notable pkg changes
:gitTagCleanUp
  Running:
    git tag -d v0.13.6
Deleted tag 'v0.13.6' (was 4186118)

BUILD SUCCESSFUL

Total time: 8.064 secs

BUILD SUCCESSFUL

Total time: 9.374 secs
```

**./gradlew testNotableRelease**
```
~/mockito/example-release$ ./gradlew testNotableRelease
  Using version '0.14.0' from 'version.properties' file.
:testNotableRelease
  It looks like we are releasing a new notable version '0.14.0'!
  Performing additional upload to 'notable versions' repository and Maven Central.
  Running:
    ./gradlew bintrayUploadAll -Prelease_version=0.14.0 -Prelease_notable=true -Pbintray_mavenCentralSync -PreleaseDryRun
Starting a Gradle Daemon, 1 busy and 4 stopped Daemons could not be reused, use --status for details
  Using version '0.14.0' supplied via 'release_version' project property.
:api:generatePomFileForJavaLibraryPublication
:api:compileJava UP-TO-DATE
:api:processResources NO-SOURCE
:api:classes UP-TO-DATE
:api:jar UP-TO-DATE
:api:javadoc
:api:javadocJar
:api:sourcesJar UP-TO-DATE
:api:publishJavaLibraryPublicationToMavenLocal
:api:bintrayUpload
:api:bintrayUpload - publishing to Bintray
  - dry run: true
  - repository: examples
  - version: 0.14.0
  - Maven Central sync: true
:impl:generatePomFileForJavaLibraryPublication
:impl:compileJava UP-TO-DATE
:impl:processResources NO-SOURCE
:impl:classes UP-TO-DATE
:impl:jar UP-TO-DATE
:impl:javadoc
:impl:javadocJar
:impl:sourcesJar UP-TO-DATE
:impl:publishJavaLibraryPublicationToMavenLocal
:impl:bintrayUpload
:impl:bintrayUpload - publishing to Bintray
  - dry run: true
  - repository: examples
  - version: 0.14.0
  - Maven Central sync: true
:bintrayUploadAll
```