### PR TITLE
Simplified notable release automation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.5.1'
+version = '0.6.0'
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/DefaultVersioningPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/DefaultVersioningPlugin.java
@@ -24,14 +24,8 @@ public class DefaultVersioningPlugin implements VersioningPlugin {
         project.getExtensions().add(VersionFile.class.getName(), versionInfo);
 
         ExtraPropertiesExtension ext = project.getExtensions().getExtraProperties();
-        final String version;
-        if (ext.has("release_version")) {
-            version = ext.get("release_version").toString();
-            LOG.lifecycle("  Building version '{}' (value supplied via 'release_version' project property).", version);
-        } else {
-            version = versionInfo.getVersion();
-            LOG.lifecycle("  Building version '{}' (value loaded from '{}' file).", version, versionFile.getName());
-        }
+        final String version = versionInfo.getVersion();
+        LOG.lifecycle("  Building version '{}' (value loaded from '{}' file).", version, versionFile.getName());
 
         project.allprojects(new Action<Project>() {
             @Override


### PR DESCRIPTION
Greatly simplified notable release

- No need to perform and additional Gradle task for the notable release. Thanks to how Bintray works, it is not needed. Previously, we triggered and extra Gradle build to perform bintrayUploadAll task to a different Bintray package. However, this does not work in Bintray. We cannot have the same version published to 2 Bintray packages if those packages are in the same Bintray repo. So we cannot push to both: "notable" and "all versions" Bintray packages. However, we don't really need this. All versions + notable versions are available under single repository url if that the packages are in the same repository. In our case, the Bintray packages are a part of the same Bintray repo so the whole process gets way simpler.
- Removed unnecessary logic from the versioning plugin. We no longer need to have special handling for extra project property "release_notable".