### PR TITLE
#36 read all project contributors and add them to pom.xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ apply plugin: 'maven'
 apply plugin: 'idea'
 apply plugin: 'groovy'
 apply plugin: 'com.gradle.plugin-publish'
-apply plugin: 'maven'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.6.7'
+version = '0.6.8'
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'
 

--- a/src/main/groovy/org/mockito/release/gradle/IncrementalReleaseNotes.java
+++ b/src/main/groovy/org/mockito/release/gradle/IncrementalReleaseNotes.java
@@ -30,7 +30,6 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
      * Release notes file this task operates on.
      */
     @InputFile
-    @OutputFile
     public File getReleaseNotesFile() {
         return releaseNotesFile;
     }
@@ -144,6 +143,16 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
      * and appends it to the top of the release notes file.
      */
     public static class UpdateTask extends IncrementalReleaseNotes {
+
+        /**
+         * Delegates to {@link IncrementalReleaseNotes#getReleaseNotesFile()}.
+         * Configured here only to specify Gradle's output file and make the task incremental.
+         */
+        @OutputFile
+        public File getReleaseNotesFile() {
+            return super.getReleaseNotesFile();
+        }
+
         @TaskAction public void updateReleaseNotes() {
             String newContent = super.getNewContent();
             FileUtil.appendToTop(newContent, getReleaseNotesFile());

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -26,7 +26,8 @@ public class ReleaseConfiguration {
 
     public ReleaseConfiguration() {
         //Configure default values
-        this.git.setTagPrefix("v");
+        git.setTagPrefix("v");
+        team.setAddContributorsToPomFromGitHub(true);
     }
 
     private boolean dryRun;
@@ -281,11 +282,33 @@ public class ReleaseConfiguration {
         public void setContributors(Collection<String> contributors) {
             configuration.put("team.contributors", contributors);
         }
+
+        /**
+         * A boolean flag for fetch all contributors from GitHub to include them in generated pom file.
+         * This is optional value, by default set to true.
+         * <p>
+         * See POM reference for <a href="https://maven.apache.org/pom.html#Contributors">Contributors</a>.
+         */
+        public boolean isAddContributorsToPomFromGitHub() {
+            return getBoolean("team.addContributorsToPomFromGitHub");
+        }
+
+        /**
+         * See {@link #isAddContributorsToPomFromGitHub()}
+         */
+        public void setAddContributorsToPomFromGitHub(Boolean addContributorsToPomFromGitHub) {
+            configuration.put("team.addContributorsToPomFromGitHub", addContributorsToPomFromGitHub);
+        }
     }
 
     //TODO unit test message creation and error handling
     private String getString(String key) {
         return (String) getValue(key, "Please configure 'releasing." + key + "' value (String).");
+    }
+
+    private Boolean getBoolean(String key) {
+        Object value = configuration.get(key);
+        return Boolean.parseBoolean(value.toString());
     }
 
     private Map getMap(String key) {

--- a/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
@@ -18,7 +18,7 @@ public class AllContributorsFetcherTask extends DefaultTask {
     private static final Logger LOG = Logging.getLogger(AllContributorsFetcherTask.class);
 
     @Input private String repository;
-    @Input private String authToken;
+    @Input private String readOnlyAuthToken;
 
     @OutputFile private File contributorsFile;
 
@@ -26,7 +26,7 @@ public class AllContributorsFetcherTask extends DefaultTask {
     public void fetchAllProjectContributorsFromGitHub() {
         LOG.lifecycle("  Fetching all contributors for project");
 
-        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, authToken);
+        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, readOnlyAuthToken);
         ProjectContributorsSet allContributorsForProject = contributorsProvider.getAllContributorsForProject();
 
         AllContributorsSerializer serializer = Contributors.getAllContributorsSerializer(contributorsFile);
@@ -37,8 +37,8 @@ public class AllContributorsFetcherTask extends DefaultTask {
         this.repository = repository;
     }
 
-    public void setAuthToken(String authToken) {
-        this.authToken = authToken;
+    public void setReadOnlyAuthToken(String readOnlyAuthToken) {
+        this.readOnlyAuthToken = readOnlyAuthToken;
     }
 
     public void setContributorsFile(File contributorsFile) {

--- a/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
@@ -26,9 +26,17 @@ public class AllContributorsFetcherTask extends DefaultTask {
     @TaskAction
     public void fetchAllProjectContributorsFromGitHub() {
         if(skipTaskExecution) {
-            LOG.lifecycle("  Fetching all contributors for project SKIPPED");
+            LOG.lifecycle("  Fetching all contributors for project SKIPPED (disabled in configuration)");
             return;
         }
+
+        // Fetching info about all contributors is expensive.
+        // Task execution is skipped when output file exist for speed up local builds.
+        if(contributorsFile.exists()) {
+            LOG.lifecycle("  Fetching all contributors for project SKIPPED (output file exist)");
+            return;
+        }
+
         LOG.lifecycle("  Fetching all contributors for project");
 
         GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, readOnlyAuthToken);

--- a/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
@@ -6,10 +6,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.mockito.release.notes.contributors.AllContributorsSerializer;
-import org.mockito.release.notes.contributors.Contributors;
-import org.mockito.release.notes.contributors.ContributorsSet;
-import org.mockito.release.notes.contributors.GitHubContributorsProvider;
+import org.mockito.release.notes.contributors.*;
 
 import java.io.File;
 
@@ -30,7 +27,7 @@ public class AllContributorsFetcherTask extends DefaultTask {
         LOG.lifecycle("  Fetching all contributors for project");
 
         GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, authToken);
-        ContributorsSet allContributorsForProject = contributorsProvider.getAllContributorsForProject();
+        ProjectContributorsSet allContributorsForProject = contributorsProvider.getAllContributorsForProject();
 
         AllContributorsSerializer serializer = Contributors.getAllContributorsSerializer(contributorsFile);
         serializer.serialize(allContributorsForProject);

--- a/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
@@ -1,0 +1,50 @@
+package org.mockito.release.internal.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.mockito.release.notes.contributors.AllContributorsSerializer;
+import org.mockito.release.notes.contributors.Contributors;
+import org.mockito.release.notes.contributors.ContributorsSet;
+import org.mockito.release.notes.contributors.GitHubContributorsProvider;
+
+import java.io.File;
+
+/**
+ * Fetch data about all project contributors and store it in file. It is used later in generation pom.xml.
+ */
+public class AllContributorsFetcherTask extends DefaultTask {
+
+    private static final Logger LOG = Logging.getLogger(AllContributorsFetcherTask.class);
+
+    @Input private String repository;
+    @Input private String authToken;
+
+    @OutputFile private File contributorsFile;
+
+    @TaskAction
+    public void fetchAllContributorsFromGitHub() {
+        LOG.lifecycle("  Fetching all contributors for project");
+
+        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, authToken);
+        ContributorsSet allContributorsForProject = contributorsProvider.getAllContributorsForProject();
+
+        AllContributorsSerializer serializer = Contributors.getAllContributorsSerializer(contributorsFile);
+        serializer.serialize(allContributorsForProject);
+    }
+
+    public void setRepository(String repository) {
+        this.repository = repository;
+    }
+
+    public void setAuthToken(String authToken) {
+        this.authToken = authToken;
+    }
+
+    public void setContributorsFile(File contributorsFile) {
+        this.contributorsFile = contributorsFile;
+    }
+}

--- a/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
@@ -23,7 +23,7 @@ public class AllContributorsFetcherTask extends DefaultTask {
     @OutputFile private File contributorsFile;
 
     @TaskAction
-    public void fetchAllContributorsFromGitHub() {
+    public void fetchAllProjectContributorsFromGitHub() {
         LOG.lifecycle("  Fetching all contributors for project");
 
         GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, authToken);

--- a/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
@@ -19,11 +19,16 @@ public class AllContributorsFetcherTask extends DefaultTask {
 
     @Input private String repository;
     @Input private String readOnlyAuthToken;
+    @Input private boolean skipTaskExecution;
 
     @OutputFile private File contributorsFile;
 
     @TaskAction
     public void fetchAllProjectContributorsFromGitHub() {
+        if(skipTaskExecution) {
+            LOG.lifecycle("  Fetching all contributors for project SKIPPED");
+            return;
+        }
         LOG.lifecycle("  Fetching all contributors for project");
 
         GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, readOnlyAuthToken);
@@ -39,6 +44,10 @@ public class AllContributorsFetcherTask extends DefaultTask {
 
     public void setReadOnlyAuthToken(String readOnlyAuthToken) {
         this.readOnlyAuthToken = readOnlyAuthToken;
+    }
+
+    public void setSkipTaskExecution(boolean skipTaskExecution) {
+        this.skipTaskExecution = skipTaskExecution;
     }
 
     public void setContributorsFile(File contributorsFile) {

--- a/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
@@ -33,7 +33,7 @@ import org.mockito.release.internal.gradle.util.PomCustomizer;
  * <ul>
  *     <li>Automatically includes "LICENSE" file in all jars.</li>
  *     <li>Adds build.dependsOn "publishToMavenLocal" to flesh out publication issues during the build</li>
- *     <li>Adds publishToMavenLocal.dependsOn "fetchAllContributorsFromGitHub" to load all contributors from GitHub</li>
+ *     <li>Adds publishToMavenLocal.dependsOn "fetchAllProjectContributorsFromGitHub" to load all contributors from GitHub</li>
  * </ul>
  */
 public class BaseJavaLibraryPlugin implements Plugin<Project> {
@@ -94,9 +94,9 @@ public class BaseJavaLibraryPlugin implements Plugin<Project> {
 
         //so that we flesh out problems with maven publication during the build process
         project.getTasks().getByName("build").dependsOn("publishToMavenLocal");
-        // TODO 1 is this dependency correct? Result of fetchAllContributorsFromGitHub is needed in
+        // TODO 1 is this dependency correct? Result of fetchAllProjectContributorsFromGitHub is needed in
         // TODO PomCustomizer.customizePom(project, publication);
         // TODO 2 Where define dependency to ContributorsPlugin?
-        project.getTasks().getByName("publishToMavenLocal").dependsOn("fetchAllContributorsFromGitHub");
+        project.getTasks().getByName("publishToMavenLocal").dependsOn("fetchAllProjectContributorsFromGitHub");
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
@@ -33,6 +33,7 @@ import org.mockito.release.internal.gradle.util.PomCustomizer;
  * <ul>
  *     <li>Automatically includes "LICENSE" file in all jars.</li>
  *     <li>Adds build.dependsOn "publishToMavenLocal" to flesh out publication issues during the build</li>
+ *     <li>Adds publishToMavenLocal.dependsOn "fetchAllContributorsFromGitHub" to load all contributors from GitHub</li>
  * </ul>
  */
 public class BaseJavaLibraryPlugin implements Plugin<Project> {
@@ -93,5 +94,9 @@ public class BaseJavaLibraryPlugin implements Plugin<Project> {
 
         //so that we flesh out problems with maven publication during the build process
         project.getTasks().getByName("build").dependsOn("publishToMavenLocal");
+        // TODO 1 is this dependency correct? Result of fetchAllContributorsFromGitHub is needed in
+        // TODO PomCustomizer.customizePom(project, publication);
+        // TODO 2 Where define dependency to ContributorsPlugin?
+        project.getTasks().getByName("publishToMavenLocal").dependsOn("fetchAllContributorsFromGitHub");
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
@@ -41,6 +41,7 @@ public class BaseJavaLibraryPlugin implements Plugin<Project> {
     private final static Logger LOG = Logging.getLogger(BaseJavaLibraryPlugin.class);
 
     final static String PUBLICATION_NAME = "javaLibrary";
+    final static String POM_TASK = "generatePomFileFor" + PUBLICATION_NAME + "Publication";
 
     public void apply(final Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();

--- a/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
@@ -40,7 +40,7 @@ public class BaseJavaLibraryPlugin implements Plugin<Project> {
 
     private final static Logger LOG = Logging.getLogger(BaseJavaLibraryPlugin.class);
 
-    final static String PUBLICATION_NAME = "javaLibrary";
+    final static String PUBLICATION_NAME = "JavaLibrary";
     final static String POM_TASK = "generatePomFileFor" + PUBLICATION_NAME + "Publication";
 
     public void apply(final Project project) {

--- a/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
@@ -97,6 +97,6 @@ public class BaseJavaLibraryPlugin implements Plugin<Project> {
         // TODO 1 is this dependency correct? Result of fetchAllProjectContributorsFromGitHub is needed in
         // TODO PomCustomizer.customizePom(project, publication);
         // TODO 2 Where define dependency to ContributorsPlugin?
-        project.getTasks().getByName("publishToMavenLocal").dependsOn("fetchAllProjectContributorsFromGitHub");
+//         project.getTasks().getByName("publishToMavenLocal").dependsOn("fetchAllProjectContributorsFromGitHub");
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -46,6 +46,19 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
         project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(GitPlugin.class);
 
+        project.allprojects(new Action<Project>() {
+            @Override
+            public void execute(final Project project) {
+                project.getPlugins().withType(JavaLibraryPlugin.class, new Action<JavaLibraryPlugin>() {
+                    @Override
+                    public void execute(JavaLibraryPlugin plugin) {
+                        project.getTasks().getByName("publishToMavenLocal")
+                                .dependsOn(":fetchAllProjectContributorsFromGitHub");
+                    }
+                });
+            }
+        });
+
         final boolean notableRelease = project.getExtensions().getByType(VersionInfo.class).isNotableRelease();
 
         //TODO use constants for all task names

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -6,7 +6,6 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Exec;
 import org.gradle.process.ExecResult;
@@ -47,24 +46,6 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
         project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(GitPlugin.class);
         project.getPlugins().apply(ContributorsPlugin.class);
-
-        project.allprojects(new Action<Project>() {
-            @Override
-            public void execute(final Project subproject) {
-                subproject.getPlugins().withType(BaseJavaLibraryPlugin.class, new Action<BaseJavaLibraryPlugin>() {
-                    @Override
-                    public void execute(BaseJavaLibraryPlugin p) {
-                        final Task fetcher = project.getTasks().getByName(ContributorsPlugin.FETCH_CONTRIBUTORS_TASK);
-                        subproject.getTasks().withType(GenerateMavenPom.class, new Action<GenerateMavenPom>() {
-                            @Override
-                            public void execute(GenerateMavenPom generateMavenPom) {
-                                generateMavenPom.dependsOn(fetcher);
-                            }
-                        });
-                    }
-                });
-            }
-        });
 
         final boolean notableRelease = project.getExtensions().getByType(VersionInfo.class).isNotableRelease();
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -45,15 +45,16 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
         project.getPlugins().apply(ReleaseNotesPlugin.class);
         project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(GitPlugin.class);
+        project.getPlugins().apply(ContributorsPlugin.class);
 
         project.allprojects(new Action<Project>() {
             @Override
-            public void execute(final Project project) {
-                project.getPlugins().withType(JavaLibraryPlugin.class, new Action<JavaLibraryPlugin>() {
+            public void execute(final Project subproject) {
+                subproject.getPlugins().withType(JavaLibraryPlugin.class, new Action<JavaLibraryPlugin>() {
                     @Override
                     public void execute(JavaLibraryPlugin plugin) {
-                        project.getTasks().getByName("publishToMavenLocal")
-                                .dependsOn(":fetchAllProjectContributorsFromGitHub");
+                        subproject.getTasks().getByName("publishToMavenLocal")
+                                .dependsOn(ContributorsPlugin.FETCH_CONTRIBUTORS_TASK);
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -54,7 +54,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                     @Override
                     public void execute(JavaLibraryPlugin plugin) {
                         subproject.getTasks().getByName("publishToMavenLocal")
-                                .dependsOn(ContributorsPlugin.FETCH_CONTRIBUTORS_TASK);
+                                .dependsOn(":" + ContributorsPlugin.FETCH_CONTRIBUTORS_TASK);
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -53,8 +53,8 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                 subproject.getPlugins().withType(JavaLibraryPlugin.class, new Action<JavaLibraryPlugin>() {
                     @Override
                     public void execute(JavaLibraryPlugin plugin) {
-                        subproject.getTasks().getByName("publishToMavenLocal")
-                                .dependsOn(":" + ContributorsPlugin.FETCH_CONTRIBUTORS_TASK);
+                        Task fetcher = project.getTasks().getByName(ContributorsPlugin.FETCH_CONTRIBUTORS_TASK);
+                        subproject.getTasks().getByName("publishToMavenLocal").dependsOn(fetcher);
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -17,6 +17,7 @@ import org.mockito.release.internal.gradle.util.TaskMaker;
 import org.mockito.release.version.VersionInfo;
 
 import static java.util.Arrays.asList;
+import static org.mockito.release.internal.gradle.BaseJavaLibraryPlugin.POM_TASK;
 
 /**
  * Opinionated continuous delivery plugin.
@@ -50,11 +51,11 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
         project.allprojects(new Action<Project>() {
             @Override
             public void execute(final Project subproject) {
-                subproject.getPlugins().withType(JavaLibraryPlugin.class, new Action<JavaLibraryPlugin>() {
+                subproject.getPlugins().withType(BaseJavaLibraryPlugin.class, new Action<BaseJavaLibraryPlugin>() {
                     @Override
-                    public void execute(JavaLibraryPlugin plugin) {
+                    public void execute(BaseJavaLibraryPlugin p) {
                         Task fetcher = project.getTasks().getByName(ContributorsPlugin.FETCH_CONTRIBUTORS_TASK);
-                        subproject.getTasks().getByName("publishToMavenLocal").dependsOn(fetcher);
+                        subproject.getTasks().getByName(POM_TASK).dependsOn(fetcher);
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -6,6 +6,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Exec;
 import org.gradle.process.ExecResult;
@@ -17,7 +18,6 @@ import org.mockito.release.internal.gradle.util.TaskMaker;
 import org.mockito.release.version.VersionInfo;
 
 import static java.util.Arrays.asList;
-import static org.mockito.release.internal.gradle.BaseJavaLibraryPlugin.POM_TASK;
 
 /**
  * Opinionated continuous delivery plugin.
@@ -54,8 +54,13 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                 subproject.getPlugins().withType(BaseJavaLibraryPlugin.class, new Action<BaseJavaLibraryPlugin>() {
                     @Override
                     public void execute(BaseJavaLibraryPlugin p) {
-                        Task fetcher = project.getTasks().getByName(ContributorsPlugin.FETCH_CONTRIBUTORS_TASK);
-                        subproject.getTasks().getByName(POM_TASK).dependsOn(fetcher);
+                        final Task fetcher = project.getTasks().getByName(ContributorsPlugin.FETCH_CONTRIBUTORS_TASK);
+                        subproject.getTasks().withType(GenerateMavenPom.class, new Action<GenerateMavenPom>() {
+                            @Override
+                            public void execute(GenerateMavenPom generateMavenPom) {
+                                generateMavenPom.dependsOn(fetcher);
+                            }
+                        });
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContributorsFetcherTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContributorsFetcherTask.java
@@ -20,8 +20,7 @@ import org.mockito.release.notes.vcs.Vcs;
 import java.io.File;
 
 /**
- * Fetch info about contributors from GitHub and store it in file. It is used later in generation release notes and
- * adding contributors to pom.xml.
+ * Fetch info about contributors from GitHub and store it in file. It is used later in generation release notes.
  */
 public class ContributorsFetcherTask extends DefaultTask {
 
@@ -35,8 +34,8 @@ public class ContributorsFetcherTask extends DefaultTask {
     @OutputFile private File contributorsFile;
 
     @TaskAction
-    public void fetchContributorsFromGitHub() {
-        LOG.lifecycle("  Fetching contributor information between revisions {}..{}", fromRevision, toRevision);
+    public void fetchLastContributorsFromGitHub() {
+        LOG.lifecycle("  Fetching contributors information between revisions {}..{}", fromRevision, toRevision);
         ProcessRunner processRunner = Exec.getProcessRunner(getProject().getRootDir());
         ContributionsProvider contributionsProvider = Vcs.getContributionsProvider(processRunner);
         ContributionSet contributions = contributionsProvider.getContributionsBetween(fromRevision, toRevision);
@@ -47,7 +46,8 @@ public class ContributorsFetcherTask extends DefaultTask {
         GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, authToken);
         ContributorsSet contributors = contributorsProvider.mapContributorsToGitHubUser(contributions, fromRev, toRevision);
 
-        new ContributorsSerializer(contributorsFile).serialize(contributors);
+        ContributorsSerializer contributorsSerializer = Contributors.getLastContributorsSerializer(contributorsFile);
+        contributorsSerializer.serialize(contributors);
     }
 
     public void setRepository(String repository) {

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContributorsFetcherTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContributorsFetcherTask.java
@@ -27,7 +27,7 @@ public class ContributorsFetcherTask extends DefaultTask {
     private static final Logger LOG = Logging.getLogger(ContributorsFetcherTask.class);
 
     @Input private String repository;
-    @Input private String authToken;
+    @Input private String readOnlyAuthToken;
     @Input private String fromRevision;
     @Input private String toRevision;
 
@@ -43,7 +43,7 @@ public class ContributorsFetcherTask extends DefaultTask {
         RevisionProvider revisionProvider = Vcs.getRevisionProvider(processRunner);
         String fromRev = revisionProvider.getRevisionForTagOrRevision(fromRevision);
 
-        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, authToken);
+        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, readOnlyAuthToken);
         ContributorsSet contributors = contributorsProvider.mapContributorsToGitHubUser(contributions, fromRev, toRevision);
 
         ContributorsSerializer contributorsSerializer = Contributors.getLastContributorsSerializer(contributorsFile);
@@ -54,8 +54,8 @@ public class ContributorsFetcherTask extends DefaultTask {
         this.repository = repository;
     }
 
-    public void setAuthToken(String authToken) {
-        this.authToken = authToken;
+    public void setReadOnlyAuthToken(String readOnlyAuthToken) {
+        this.readOnlyAuthToken = readOnlyAuthToken;
     }
 
     public void setToRevision(String toRevision) {

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
@@ -23,6 +23,8 @@ import static org.mockito.release.internal.gradle.configuration.DeferredConfigur
  */
 public class ContributorsPlugin implements Plugin<Project> {
 
+    public final static String FETCH_CONTRIBUTORS_TASK = "fetchAllProjectContributorsFromGitHub";
+
     public void apply(final Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
 
@@ -57,7 +59,7 @@ public class ContributorsPlugin implements Plugin<Project> {
     }
 
     private void createTaskFetchAllProjectContributorsFromGitHub(final Project project, final ReleaseConfiguration conf) {
-        project.getTasks().create("fetchAllProjectContributorsFromGitHub", AllContributorsFetcherTask.class, new Action<AllContributorsFetcherTask>() {
+        project.getTasks().create(FETCH_CONTRIBUTORS_TASK, AllContributorsFetcherTask.class, new Action<AllContributorsFetcherTask>() {
             @Override
             public void execute(final AllContributorsFetcherTask task) {
                 task.setGroup(TaskMaker.TASK_GROUP);

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
@@ -17,7 +17,8 @@ import static org.mockito.release.internal.gradle.configuration.DeferredConfigur
  * Adds and configures tasks for getting contributor git user to GitHub user mappings.
  * Useful for release notes and pom.xml generation. Adds tasks:
  * <ul>
- *     <li>fetchContributorsFromGitHub - {@link ContributorsFetcherTask}</li>
+ *     <li>fetchLastContributorsFromGitHub - {@link ContributorsFetcherTask}</li>
+ *     <li>fetchAllProjectContributorsFromGitHub - {@link AllContributorsFetcherTask}</li>
  * </ul>
  */
 public class ContributorsPlugin implements Plugin<Project> {
@@ -25,7 +26,13 @@ public class ContributorsPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
 
-        project.getTasks().create("fetchContributorsFromGitHub", ContributorsFetcherTask.class, new Action<ContributorsFetcherTask>() {
+        createTaskFetchLastContributorsFromGitHub(project, ext);
+
+        createTaskFetchAllProjectContributorsFromGitHub(project, ext);
+    }
+
+    private void createTaskFetchLastContributorsFromGitHub(final Project project, final ExtContainer ext) {
+        project.getTasks().create("fetchLastContributorsFromGitHub", ContributorsFetcherTask.class, new Action<ContributorsFetcherTask>() {
             @Override
             public void execute(final ContributorsFetcherTask task) {
                 task.setGroup(TaskMaker.TASK_GROUP);
@@ -37,7 +44,7 @@ public class ContributorsPlugin implements Plugin<Project> {
                 deferredConfiguration(project, new Runnable() {
                     public void run() {
                         String fromRevision = fromRevision(project, conf);
-                        File contributorsFile = contributorsFile(project, fromRevision, toRevision);
+                        File contributorsFile = lastContributorsFile(project, fromRevision, toRevision);
 
                         task.setAuthToken(conf.getGitHub().getReadOnlyAuthToken());
                         task.setRepository(conf.getGitHub().getRepository());
@@ -47,7 +54,26 @@ public class ContributorsPlugin implements Plugin<Project> {
                 });
             }
         });
+    }
 
+    private void createTaskFetchAllProjectContributorsFromGitHub(final Project project, final ExtContainer ext) {
+        project.getTasks().create("fetchAllProjectContributorsFromGitHub", AllContributorsFetcherTask.class, new Action<AllContributorsFetcherTask>() {
+            @Override
+            public void execute(final AllContributorsFetcherTask task) {
+                task.setGroup(TaskMaker.TASK_GROUP);
+                task.setDescription("Fetch info about all project contributors from GitHub and store it in file");
+
+                LazyConfigurer.getConfigurer(project).configureLazily(task, new Runnable() {
+                    @Override
+                    public void run() {
+                        File contributorsFile = allProjectContributorsFile(project);
+                        task.setAuthToken(ext.getGitHubReadOnlyAuthToken());
+                        task.setRepository(ext.getGitHubRepository());
+                        task.setContributorsFile(contributorsFile);
+                    }
+                });
+            }
+        });
     }
 
     private String fromRevision(Project project, ReleaseConfiguration conf) {
@@ -55,10 +81,15 @@ public class ContributorsPlugin implements Plugin<Project> {
         return "v" + Notes.previousVersion(firstLine).getPreviousVersion();
     }
 
-    private File contributorsFile(Project project, String fromRevision, String toRevision) {
-        String contributorsFileName = Contributors.getContributorsFileName(
+    private File lastContributorsFile(Project project, String fromRevision, String toRevision) {
+        String contributorsFileName = Contributors.getLastContributorsFileName(
                 project.getBuildDir().getAbsolutePath(), fromRevision, toRevision);
         return new File(contributorsFileName);
+    }
+
+    private File allProjectContributorsFile(Project project) {
+        String fileName = Contributors.getAllProjectContributorsFileName(project.getBuildDir().getAbsolutePath());
+        return new File(fileName);
     }
 }
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
@@ -26,12 +26,12 @@ public class ContributorsPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
 
-        createTaskFetchLastContributorsFromGitHub(project, ext);
+        createTaskFetchLastContributorsFromGitHub(project, conf);
 
-        createTaskFetchAllProjectContributorsFromGitHub(project, ext);
+        createTaskFetchAllProjectContributorsFromGitHub(project, conf);
     }
 
-    private void createTaskFetchLastContributorsFromGitHub(final Project project, final ExtContainer ext) {
+    private void createTaskFetchLastContributorsFromGitHub(final Project project, final ReleaseConfiguration conf) {
         project.getTasks().create("fetchLastContributorsFromGitHub", ContributorsFetcherTask.class, new Action<ContributorsFetcherTask>() {
             @Override
             public void execute(final ContributorsFetcherTask task) {
@@ -56,19 +56,19 @@ public class ContributorsPlugin implements Plugin<Project> {
         });
     }
 
-    private void createTaskFetchAllProjectContributorsFromGitHub(final Project project, final ExtContainer ext) {
+    private void createTaskFetchAllProjectContributorsFromGitHub(final Project project, final ReleaseConfiguration conf) {
         project.getTasks().create("fetchAllProjectContributorsFromGitHub", AllContributorsFetcherTask.class, new Action<AllContributorsFetcherTask>() {
             @Override
             public void execute(final AllContributorsFetcherTask task) {
                 task.setGroup(TaskMaker.TASK_GROUP);
                 task.setDescription("Fetch info about all project contributors from GitHub and store it in file");
 
-                LazyConfigurer.getConfigurer(project).configureLazily(task, new Runnable() {
+                deferredConfiguration(project, new Runnable() {
                     @Override
                     public void run() {
                         File contributorsFile = allProjectContributorsFile(project);
-                        task.setAuthToken(ext.getGitHubReadOnlyAuthToken());
-                        task.setRepository(ext.getGitHubRepository());
+                        task.setAuthToken(conf.getGitHub().getReadOnlyAuthToken());
+                        task.setRepository(conf.getGitHub().getRepository());
                         task.setContributorsFile(contributorsFile);
                     }
                 });

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
@@ -46,7 +46,7 @@ public class ContributorsPlugin implements Plugin<Project> {
                         String fromRevision = fromRevision(project, conf);
                         File contributorsFile = lastContributorsFile(project, fromRevision, toRevision);
 
-                        task.setAuthToken(conf.getGitHub().getReadOnlyAuthToken());
+                        task.setReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
                         task.setRepository(conf.getGitHub().getRepository());
                         task.setFromRevision(fromRevision);
                         task.setContributorsFile(contributorsFile);
@@ -67,7 +67,7 @@ public class ContributorsPlugin implements Plugin<Project> {
                     @Override
                     public void run() {
                         File contributorsFile = allProjectContributorsFile(project);
-                        task.setAuthToken(conf.getGitHub().getReadOnlyAuthToken());
+                        task.setReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
                         task.setRepository(conf.getGitHub().getRepository());
                         task.setContributorsFile(contributorsFile);
                     }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
@@ -72,6 +72,7 @@ public class ContributorsPlugin implements Plugin<Project> {
                         task.setReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
                         task.setRepository(conf.getGitHub().getRepository());
                         task.setContributorsFile(contributorsFile);
+                        task.setSkipTaskExecution(!conf.getTeam().isAddContributorsToPomFromGitHub());
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
@@ -86,7 +86,7 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
                 task.setReleaseNotesFile(project.file(conf.getReleaseNotes().getFile())); //TODO add sensible default
                 task.setGitHubReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
                 task.setGitHubRepository(conf.getGitHub().getRepository());
-                //TODO, do we need below force?
+                //TODO MS do we need below force?
                 forceTaskToAlwaysGeneratePreview(task);
             }
         });

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
@@ -3,8 +3,6 @@ package org.mockito.release.internal.gradle;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.specs.Spec;
 import org.mockito.release.gradle.IncrementalReleaseNotes;
 import org.mockito.release.gradle.ReleaseConfiguration;
 import org.mockito.release.internal.gradle.configuration.DeferredConfiguration;
@@ -86,8 +84,6 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
                 task.setReleaseNotesFile(project.file(conf.getReleaseNotes().getFile())); //TODO add sensible default
                 task.setGitHubReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
                 task.setGitHubRepository(conf.getGitHub().getRepository());
-                //TODO MS do we need below force?
-                forceTaskToAlwaysGeneratePreview(task);
             }
         });
     }
@@ -112,14 +108,5 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
     private static File getTemporaryReleaseNotesFile(Project project){
         String path = project.getBuildDir()  + TEMP_SERIALIZED_NOTES_FILE;
         return project.file(path);
-    }
-
-    private static void forceTaskToAlwaysGeneratePreview(IncrementalReleaseNotes task) {
-        task.getOutputs().upToDateWhen(new Spec<Task>() {
-            @Override
-            public boolean isSatisfiedBy(Task element) {
-                return false;
-            }
-        });
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
@@ -79,7 +79,7 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
     }
 
     private static void preconfigureIncrementalNotes(final IncrementalReleaseNotes task, final Project project, final ReleaseConfiguration conf) {
-        task.dependsOn("fetchContributorsFromGitHub");
+        task.dependsOn("fetchLastContributorsFromGitHub");
         DeferredConfiguration.deferredConfiguration(project, new Runnable() {
             public void run() {
                 task.setGitHubLabelMapping(conf.getReleaseNotes().getLabelMapping()); //TODO make it optional

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/PomCustomizer.groovy
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/PomCustomizer.groovy
@@ -82,8 +82,9 @@ class PomCustomizer {
             }
 
             def contributorsNode = root.appendNode('contributors')
-            def fileName = Contributors.getAllProjectContributorsFileName(project.getBuildDir())
-            ContributorsToPom.include(contributorsNode, fileName, conf.team.contributors, conf.team.developers)
+            def rootBuildDir = project.getRootProject().getBuildDir().getAbsolutePath()
+            def contributorsPath = Contributors.getAllProjectContributorsFileName(rootBuildDir)
+            ContributorsToPom.include(contributorsNode, contributorsPath, conf.team.contributors, conf.team.developers)
         }
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/PomCustomizer.groovy
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/PomCustomizer.groovy
@@ -5,9 +5,8 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.publish.maven.MavenPublication
 import org.mockito.release.gradle.ReleaseConfiguration
-import org.mockito.release.notes.contributors.AllProjectContributorsReader
-import org.mockito.release.notes.contributors.AllProjectsContributorsProvider
 import org.mockito.release.notes.contributors.Contributors
+import org.mockito.release.notes.contributors.ContributorsToPom
 
 class PomCustomizer {
 
@@ -84,13 +83,7 @@ class PomCustomizer {
 
             def contributorsNode = root.appendNode('contributors')
             def fileName = Contributors.getAllProjectContributorsFileName(project.getBuildDir())
-            AllProjectContributorsReader reader = AllProjectsContributorsProvider.allProjectContributorsReader()
-            def contributors = reader.loadAllContributors(fileName)
-            contributors.getAllContributors().each {
-                def c = contributorsNode.appendNode('contributor')
-                c.appendNode('name', it.name != "" ? it.name : it.login)
-                c.appendNode('url', it.profileUrl)
-            }
+            ContributorsToPom.include(contributorsNode, fileName, conf.team.contributors, conf.team.developers)
         }
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/PomCustomizer.groovy
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/PomCustomizer.groovy
@@ -5,6 +5,9 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.publish.maven.MavenPublication
 import org.mockito.release.gradle.ReleaseConfiguration
+import org.mockito.release.notes.contributors.AllProjectContributorsReader
+import org.mockito.release.notes.contributors.AllProjectsContributorsProvider
+import org.mockito.release.notes.contributors.Contributors
 
 class PomCustomizer {
 
@@ -79,13 +82,14 @@ class PomCustomizer {
                 d.appendNode('url', "https://github.com/${split[0]}")
             }
 
-            def contributors = root.appendNode('contributors')
-            conf.team.contributors.each {
-                def split = it.split(':')
-                assert split.length == 2
-                def c = contributors.appendNode('contributor')
-                c.appendNode('name', split[1])
-                c.appendNode('url', "https://github.com/${split[0]}")
+            def contributorsNode = root.appendNode('contributors')
+            def fileName = Contributors.getAllProjectContributorsFileName(project.getBuildDir())
+            AllProjectContributorsReader reader = AllProjectsContributorsProvider.allProjectContributorsReader()
+            def contributors = reader.loadAllContributors(fileName)
+            contributors.getAllContributors().each {
+                def c = contributorsNode.appendNode('contributor')
+                c.appendNode('name', it.name != "" ? it.name : it.login)
+                c.appendNode('url', it.profileUrl)
             }
         }
     }

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/PomCustomizer.groovy
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/PomCustomizer.groovy
@@ -84,7 +84,11 @@ class PomCustomizer {
             def contributorsNode = root.appendNode('contributors')
             def rootBuildDir = project.getRootProject().getBuildDir().getAbsolutePath()
             def contributorsPath = Contributors.getAllProjectContributorsFileName(rootBuildDir)
-            ContributorsToPom.include(contributorsNode, contributorsPath, conf.team.contributors, conf.team.developers)
+            ContributorsToPom.include(contributorsNode,
+                    contributorsPath,
+                    conf.team.contributors,
+                    conf.team.developers,
+                    conf.team.addContributorsToPomFromGitHub)
         }
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
+++ b/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
@@ -31,7 +31,7 @@ class GitNotesBuilder implements NotesBuilder {
     private static final Logger LOG = Logging.getLogger(GitNotesBuilder.class);
 
     private final File workDir;
-    private final String authToken;
+    private final String readOnlyAuthToken;
     private final File buildDir;
     private final String repository;
 
@@ -39,13 +39,13 @@ class GitNotesBuilder implements NotesBuilder {
      * @param workDir the working directory for external processes execution (for example: git log)
      * @param buildDir build dir
      * @param repository GitHub repository, for example: "mockito/mockito"
-     * @param authToken the GitHub auth token
+     * @param readOnlyAuthToken the GitHub auth token
      */
-    GitNotesBuilder(File workDir, File buildDir, String repository, String authToken) {
+    GitNotesBuilder(File workDir, File buildDir, String repository, String readOnlyAuthToken) {
         this.workDir = workDir;
         this.buildDir = buildDir;
         this.repository = repository;
-        this.authToken = authToken;
+        this.readOnlyAuthToken = readOnlyAuthToken;
     }
 
     public String buildNotes(String version, String fromRevision, String toRevision, final Map<String, String> labels) {
@@ -62,7 +62,7 @@ class GitNotesBuilder implements NotesBuilder {
         String contributorsFileName = Contributors.getLastContributorsFileName(buildDir.getAbsolutePath(), fromRevision, toRevision);
         ContributorsSet contributors = contributorsReader.loadContributors(contributorsFileName, fromRev, toRevision);
 
-        ImprovementsProvider improvementsProvider = Improvements.getGitHubProvider(repository, authToken);
+        ImprovementsProvider improvementsProvider = Improvements.getGitHubProvider(repository, readOnlyAuthToken);
         Collection<Improvement> improvements = improvementsProvider.getImprovements(contributions, Collections.<String>emptyList(), false);
 
         ReleaseNotesData data = new DefaultReleaseNotesData(version, new Date(), contributions, improvements, contributors, fromRevision, toRevision);

--- a/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
+++ b/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
@@ -59,7 +59,7 @@ class GitNotesBuilder implements NotesBuilder {
         String fromRev = revisionProvider.getRevisionForTagOrRevision(fromRevision);
 
         ContributorsReader contributorsReader = ContributorsLoader.getContributorsReader();
-        String contributorsFileName = Contributors.getContributorsFileName(buildDir.getAbsolutePath(), fromRevision, toRevision);
+        String contributorsFileName = Contributors.getLastContributorsFileName(buildDir.getAbsolutePath(), fromRevision, toRevision);
         ContributorsSet contributors = contributorsReader.loadContributors(contributorsFileName, fromRev, toRevision);
 
         ImprovementsProvider improvementsProvider = Improvements.getGitHubProvider(repository, authToken);

--- a/src/main/groovy/org/mockito/release/notes/contributors/AllContributorsSerializer.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/AllContributorsSerializer.java
@@ -22,16 +22,16 @@ public class AllContributorsSerializer {
         this.file = file;
     }
 
-    public void serialize(ContributorsSet<ProjectContributor> contributorsSet) {
+    public void serialize(ProjectContributorsSet contributorsSet) {
         Collection<ProjectContributor> allContributors = contributorsSet.getAllContributors();
         String json = Jsoner.serialize(allContributors);
         LOG.info("Serialize contributors to: {}", json);
         IOUtil.writeFile(file, json);
     }
 
-    public ContributorsSet<Contributor> desrialize() {
+    public ProjectContributorsSet desrialize() {
         String json = "";
-        ContributorsSet set = new DefaultContributorsSet();
+        ProjectContributorsSet set = new DefaultProjectContributorsSet();
         try {
             json = IOUtil.readFully(file);
             LOG.info("Deserialize project contributors from: {}", json);

--- a/src/main/groovy/org/mockito/release/notes/contributors/AllContributorsSerializer.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/AllContributorsSerializer.java
@@ -6,23 +6,24 @@ import org.json.simple.JsonArray;
 import org.json.simple.JsonObject;
 import org.json.simple.Jsoner;
 import org.mockito.release.notes.model.Contributor;
+import org.mockito.release.notes.model.ProjectContributor;
 import org.mockito.release.notes.util.IOUtil;
 
 import java.io.File;
 import java.util.Collection;
 
-public class ContributorsSerializer {
+public class AllContributorsSerializer {
 
-    private static final Logger LOG = Logging.getLogger(ContributorsSerializer.class);
+    private static final Logger LOG = Logging.getLogger(AllContributorsSerializer.class);
 
     private final File file;
 
-    public ContributorsSerializer(File file) {
+    public AllContributorsSerializer(File file) {
         this.file = file;
     }
 
-    public void serialize(ContributorsSet<Contributor> contributorsSet) {
-        Collection<Contributor> allContributors = contributorsSet.getAllContributors();
+    public void serialize(ContributorsSet<ProjectContributor> contributorsSet) {
+        Collection<ProjectContributor> allContributors = contributorsSet.getAllContributors();
         String json = Jsoner.serialize(allContributors);
         LOG.info("Serialize contributors to: {}", json);
         IOUtil.writeFile(file, json);
@@ -33,14 +34,15 @@ public class ContributorsSerializer {
         ContributorsSet set = new DefaultContributorsSet();
         try {
             json = IOUtil.readFully(file);
-            LOG.info("Deserialize contributors from: {}", json);
+            LOG.info("Deserialize project contributors from: {}", json);
             JsonArray array = (JsonArray) Jsoner.deserialize(json);
             for (Object object : array) {
                 JsonObject jsonObject = (JsonObject) object;
                 String name = jsonObject.getString("name");
                 String login = jsonObject.getString("login");
                 String profileUrl = jsonObject.getString("profileUrl");
-                set.addContributor(new DefaultContributor(name, login, profileUrl));
+                Integer numberOfContributions = jsonObject.getInteger("numberOfContributions");
+                set.addContributor(new DefaultProjectContributor(name, login, profileUrl, numberOfContributions));
             }
         } catch (Exception e) {
             throw new RuntimeException("Can't deserialize JSON: " + json, e);

--- a/src/main/groovy/org/mockito/release/notes/contributors/AllContributorsSerializer.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/AllContributorsSerializer.java
@@ -29,7 +29,7 @@ public class AllContributorsSerializer {
         IOUtil.writeFile(file, json);
     }
 
-    public ProjectContributorsSet desrialize() {
+    public ProjectContributorsSet deserialize() {
         String json = "";
         ProjectContributorsSet set = new DefaultProjectContributorsSet();
         try {

--- a/src/main/groovy/org/mockito/release/notes/contributors/AllProjectContributorsReader.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/AllProjectContributorsReader.java
@@ -1,0 +1,5 @@
+package org.mockito.release.notes.contributors;
+
+public interface AllProjectContributorsReader {
+    ProjectContributorsSet loadAllContributors(String filePath);
+}

--- a/src/main/groovy/org/mockito/release/notes/contributors/AllProjectsContributorsProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/AllProjectsContributorsProvider.java
@@ -1,0 +1,8 @@
+package org.mockito.release.notes.contributors;
+
+public class AllProjectsContributorsProvider {
+
+    public static AllProjectContributorsReader getAllProjectContributorsReader() {
+        return new DefaultAllProjectContributorsReader();
+    }
+}

--- a/src/main/groovy/org/mockito/release/notes/contributors/Contributors.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/Contributors.java
@@ -14,10 +14,10 @@ public class Contributors {
      * Fetches contribiutors from GitHub. Needs GitHub auth token.
      *
      * @param repository name of GitHub repository, for example: "mockito/mockito"
-     * @param authToken the GitHub auth token
+     * @param readOnlyAuthToken the GitHub auth token
      */
-    public static GitHubContributorsProvider getGitHubContibutorsProvider(String repository, String authToken) {
-        return new GitHubContributorsProvider(repository, authToken);
+    public static GitHubContributorsProvider getGitHubContibutorsProvider(String repository, String readOnlyAuthToken) {
+        return new GitHubContributorsProvider(repository, readOnlyAuthToken);
     }
 
     /**

--- a/src/main/groovy/org/mockito/release/notes/contributors/Contributors.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/Contributors.java
@@ -1,11 +1,14 @@
 package org.mockito.release.notes.contributors;
 
+import java.io.File;
+
 /**
  * Contributors based on some system outside of the vcs.
  */
 public class Contributors {
 
-    private static final String CONTRIBUTORS_FILE_PATH = "/contributors-%s-%s.json";
+    private static final String LAST_CONTRIBUTORS_FILE_PATH = "/contributors/contributors-%s-%s.json";
+    private static final String ALL_PROJECT_CONTRIBUTORS_FILE_PATH = "/contributors/project-contributors.json";
 
     /**
      * Fetches contribiutors from GitHub. Needs GitHub auth token.
@@ -17,7 +20,42 @@ public class Contributors {
         return new GitHubContributorsProvider(repository, authToken);
     }
 
-    public static String getContributorsFileName(String buildDir, String fromRev, String toRevision) {
-        return buildDir + String.format(CONTRIBUTORS_FILE_PATH, fromRev, toRevision);
+    /**
+     * Generate file path where last contributors are stored.
+     * @param buildDir project build dir
+     * @param fromRev from revision or tag
+     * @param toRevision end revision or 'HEAD'
+     * @return file path
+     */
+    public static String getLastContributorsFileName(String buildDir, String fromRev, String toRevision) {
+        return buildDir + String.format(LAST_CONTRIBUTORS_FILE_PATH, fromRev, toRevision);
     }
+
+    /**
+     * Generate file path where all project contributors are stored.
+     * @param buildDir project build dir
+     * @return file path
+     */
+    public static String getAllProjectContributorsFileName(String buildDir) {
+        return buildDir + ALL_PROJECT_CONTRIBUTORS_FILE_PATH;
+    }
+
+    /**
+     * Return Json serializer for last last contributions
+     * @param contributorsFile file where last contributions are stored
+     * @return instance of {@link ContributorsSerializer}
+     */
+    public static ContributorsSerializer getLastContributorsSerializer(File contributorsFile) {
+        return new ContributorsSerializer(contributorsFile);
+    }
+
+    /**
+     * Return Json serializer for all project contributors
+     * @param contributorsFile file where all project contributions are stored
+     * @return instance of {@link AllContributorsSerializer}
+     */
+    public static AllContributorsSerializer getAllContributorsSerializer(File contributorsFile) {
+        return new AllContributorsSerializer(contributorsFile);
+    }
+
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/ContributorsProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/ContributorsProvider.java
@@ -6,5 +6,5 @@ public interface ContributorsProvider {
 
     ContributorsSet mapContributorsToGitHubUser(ContributionSet contributions, String fromRevision, String toRevision);
 
-    ContributorsSet getAllContributorsForProject();
+    ProjectContributorsSet getAllContributorsForProject();
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/ContributorsProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/ContributorsProvider.java
@@ -5,4 +5,6 @@ import org.mockito.release.notes.model.ContributionSet;
 public interface ContributorsProvider {
 
     ContributorsSet mapContributorsToGitHubUser(ContributionSet contributions, String fromRevision, String toRevision);
+
+    ContributorsSet getAllContributorsForProject();
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/ContributorsSerializer.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/ContributorsSerializer.java
@@ -21,14 +21,14 @@ public class ContributorsSerializer {
         this.file = file;
     }
 
-    public void serialize(ContributorsSet<Contributor> contributorsSet) {
+    public void serialize(ContributorsSet contributorsSet) {
         Collection<Contributor> allContributors = contributorsSet.getAllContributors();
         String json = Jsoner.serialize(allContributors);
         LOG.info("Serialize contributors to: {}", json);
         IOUtil.writeFile(file, json);
     }
 
-    public ContributorsSet<Contributor> desrialize() {
+    public ContributorsSet desrialize() {
         String json = "";
         ContributorsSet set = new DefaultContributorsSet();
         try {

--- a/src/main/groovy/org/mockito/release/notes/contributors/ContributorsSerializer.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/ContributorsSerializer.java
@@ -28,7 +28,7 @@ public class ContributorsSerializer {
         IOUtil.writeFile(file, json);
     }
 
-    public ContributorsSet desrialize() {
+    public ContributorsSet deserialize() {
         String json = "";
         ContributorsSet set = new DefaultContributorsSet();
         try {

--- a/src/main/groovy/org/mockito/release/notes/contributors/ContributorsSet.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/ContributorsSet.java
@@ -5,15 +5,15 @@ import org.mockito.release.notes.model.Contributor;
 import java.util.Collection;
 import java.util.Set;
 
-public interface ContributorsSet {
+public interface ContributorsSet<T extends Contributor> {
 
-    Contributor findByAuthorName(String authorName);
+    T findByAuthorName(String authorName);
 
-    void addContributor(Contributor contributor);
+    void addContributor(T contributor);
 
-    void addAllContributors(Set<Contributor> contributors);
+    void addAllContributors(Set<T> contributors);
 
     int size();
 
-    Collection<Contributor> getAllContributors();
+    Collection<T> getAllContributors();
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/ContributorsSet.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/ContributorsSet.java
@@ -5,15 +5,15 @@ import org.mockito.release.notes.model.Contributor;
 import java.util.Collection;
 import java.util.Set;
 
-public interface ContributorsSet<T extends Contributor> {
+public interface ContributorsSet {
 
-    T findByAuthorName(String authorName);
+    Contributor findByAuthorName(String authorName);
 
-    void addContributor(T contributor);
+    void addContributor(Contributor contributor);
 
-    void addAllContributors(Set<T> contributors);
+    void addAllContributors(Set<Contributor> contributors);
 
     int size();
 
-    Collection<T> getAllContributors();
+    Collection<Contributor> getAllContributors();
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/ContributorsToPom.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/ContributorsToPom.java
@@ -1,0 +1,92 @@
+package org.mockito.release.notes.contributors;
+
+import groovy.util.Node;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.mockito.release.notes.model.ProjectContributor;
+
+import java.util.*;
+
+public class ContributorsToPom {
+
+    private static final Logger LOG = Logging.getLogger(GitHubAllContributorsFetcher.class);
+
+    /**
+     * Add contributors to node. Contributors comes from file generated earlier by
+     * `fetchAllProjectContributorsFromGitHub` and from contributors list (3rd param).
+     * Contributors defined in developers list are ignored to avoid duplication.
+     *
+     * @param contributorsNode       contributors node in pom.xml where contributors will be add
+     * @param fileName               a file with fetched all project contributors from GitHub
+     * @param contributorsStringList list of contributors in format: login:name_surname
+     * @param developers             list of developers in format: login:name_surname
+     */
+    public static void include(Node contributorsNode, String fileName, List<String> contributorsStringList, List<String> developers) {
+        AllProjectContributorsReader reader = AllProjectsContributorsProvider.getAllProjectContributorsReader();
+        ProjectContributorsSet contributorsSet = reader.loadAllContributors(fileName);
+        new ContributorsToPom().include(contributorsNode, contributorsSet.getAllContributors(), contributorsStringList, developers);
+    }
+
+    /**
+     * Add contributors to node. Contributors defined in developers list are ignored to avoid duplication.
+     *
+     * @param contributorsNode       contributors node in pom.xml where contributors will be add
+     * @param contributorsSet        set of contributors from GitHub
+     * @param contributorsStringList list of contributors in format: login:name_surname
+     * @param developersStringList             list of developers in format: login:name_surname
+     */
+    void include(Node contributorsNode,
+                 Set<ProjectContributor> contributorsSet,
+                 List<String> contributorsStringList,
+                 List<String> developersStringList) {
+        List<ProjectContributor> contributors = convert(contributorsStringList);
+        List<ProjectContributor> developers = convert(developersStringList);
+        for (ProjectContributor contributor : contributors) {
+            addNode(contributorsNode, contributor);
+        }
+        for (ProjectContributor contributor : contributorsSet) {
+            if(needAddContributorToNode(contributor, developers)) {
+                addNode(contributorsNode, contributor);
+            }
+        }
+    }
+
+    private List<ProjectContributor> convert(List<String> contributorsStringList) {
+        List<ProjectContributor> result = new ArrayList<ProjectContributor>();
+        for (String text : contributorsStringList) {
+            String[] split = text.split(":");
+            if (split.length != 2) {
+                String message = String.format("%s%s%s%s%s",
+                        "Wrong format of contributor. ",
+                        "It needs to contains only one : (colon), but it contains ",
+                        split.length,
+                        ". Wrong entry: ",
+                        text);
+                throw new RuntimeException(message);
+            }
+            result.add(new DefaultProjectContributor(split[1], split[0], "https://github.com/" + split[0], -1));
+        }
+        return result;
+    }
+
+    private void addNode(Node contributorsNode, ProjectContributor projectContributor) {
+        Node node = contributorsNode.appendNode("contributor");
+        node.appendNode("name", extractName(projectContributor));
+        node.appendNode("url", projectContributor.getProfileUrl());
+    }
+
+    private String extractName(ProjectContributor projectContributor) {
+        return projectContributor.getName().isEmpty() ? projectContributor.getLogin() : projectContributor.getName();
+    }
+
+    private boolean needAddContributorToNode(ProjectContributor contributor, List<ProjectContributor> developers) {
+        for (ProjectContributor developer : developers) {
+            if(developer.getLogin().equals(contributor.getLogin())) {
+                LOG.info("Ignore adding " + contributor
+                        + " to contributors list in pom.xml because of being on developers list");
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/groovy/org/mockito/release/notes/contributors/ContributorsToPom.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/ContributorsToPom.java
@@ -21,10 +21,21 @@ public class ContributorsToPom {
      * @param contributorsStringList list of contributors in format: login:name_surname
      * @param developers             list of developers in format: login:name_surname
      */
-    public static void include(Node contributorsNode, String fileName, List<String> contributorsStringList, List<String> developers) {
-        AllProjectContributorsReader reader = AllProjectsContributorsProvider.getAllProjectContributorsReader();
-        ProjectContributorsSet contributorsSet = reader.loadAllContributors(fileName);
+    public static void include(Node contributorsNode,
+                               String fileName,
+                               List<String> contributorsStringList,
+                               List<String> developers,
+                               boolean addContributorsToPomFromGitHub) {
+        ProjectContributorsSet contributorsSet = loadContributorsSet(fileName, addContributorsToPomFromGitHub);
         new ContributorsToPom().include(contributorsNode, contributorsSet.getAllContributors(), contributorsStringList, developers);
+    }
+
+    private static ProjectContributorsSet loadContributorsSet(String fileName, boolean addContributorsToPomFromGitHub) {
+        if(addContributorsToPomFromGitHub) {
+            AllProjectContributorsReader reader = AllProjectsContributorsProvider.getAllProjectContributorsReader();
+            return reader.loadAllContributors(fileName);
+        }
+        return new DefaultProjectContributorsSet();
     }
 
     /**

--- a/src/main/groovy/org/mockito/release/notes/contributors/DefaultAllProjectContributorsReader.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/DefaultAllProjectContributorsReader.java
@@ -1,0 +1,12 @@
+package org.mockito.release.notes.contributors;
+
+import java.io.File;
+
+public class DefaultAllProjectContributorsReader implements AllProjectContributorsReader {
+
+    @Override
+    public ProjectContributorsSet loadAllContributors(String filePath) {
+        return new AllContributorsSerializer(new File(filePath)).desrialize();
+    }
+
+}

--- a/src/main/groovy/org/mockito/release/notes/contributors/DefaultAllProjectContributorsReader.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/DefaultAllProjectContributorsReader.java
@@ -6,7 +6,7 @@ public class DefaultAllProjectContributorsReader implements AllProjectContributo
 
     @Override
     public ProjectContributorsSet loadAllContributors(String filePath) {
-        return new AllContributorsSerializer(new File(filePath)).desrialize();
+        return new AllContributorsSerializer(new File(filePath)).deserialize();
     }
 
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/DefaultContributorsReader.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/DefaultContributorsReader.java
@@ -7,6 +7,6 @@ public class DefaultContributorsReader implements ContributorsReader {
     @Override
     public ContributorsSet loadContributors(String filePath, String fromRev, String toRevision) {
         ContributorsSerializer serializer = new ContributorsSerializer(new File(filePath));
-        return serializer.desrialize();
+        return serializer.deserialize();
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/DefaultContributorsSet.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/DefaultContributorsSet.java
@@ -8,27 +8,27 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-class DefaultContributorsSet implements ContributorsSet, Serializable{
+class DefaultContributorsSet<E extends Contributor> implements ContributorsSet<E>, Serializable {
 
-    private final Map<String, Contributor> map;
+    private final Map<String, E> map;
 
     DefaultContributorsSet() {
-        map = new HashMap<String, Contributor>();
+        map = new HashMap<String, E>();
     }
 
     @Override
-    public Contributor findByAuthorName(String authorName) {
+    public E findByAuthorName(String authorName) {
         return map.get(authorName);
     }
 
     @Override
-    public void addContributor(Contributor contributor) {
+    public void addContributor(E contributor) {
         map.put(contributor.getName(), contributor);
     }
 
     @Override
-    public void addAllContributors(Set<Contributor> contributors) {
-        for (Contributor contributor : contributors) {
+    public void addAllContributors(Set<E> contributors) {
+        for (E contributor : contributors) {
             map.put(contributor.getName(), contributor);
         }
     }
@@ -39,7 +39,7 @@ class DefaultContributorsSet implements ContributorsSet, Serializable{
     }
 
     @Override
-    public Collection<Contributor> getAllContributors() {
+    public Collection<E> getAllContributors() {
         return map.values();
     }
 

--- a/src/main/groovy/org/mockito/release/notes/contributors/DefaultContributorsSet.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/DefaultContributorsSet.java
@@ -8,27 +8,27 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-class DefaultContributorsSet<E extends Contributor> implements ContributorsSet<E>, Serializable {
+class DefaultContributorsSet implements ContributorsSet, Serializable {
 
-    private final Map<String, E> map;
+    private final Map<String, Contributor> map;
 
     DefaultContributorsSet() {
-        map = new HashMap<String, E>();
+        map = new HashMap<String, Contributor>();
     }
 
     @Override
-    public E findByAuthorName(String authorName) {
+    public Contributor findByAuthorName(String authorName) {
         return map.get(authorName);
     }
 
     @Override
-    public void addContributor(E contributor) {
+    public void addContributor(Contributor contributor) {
         map.put(contributor.getName(), contributor);
     }
 
     @Override
-    public void addAllContributors(Set<E> contributors) {
-        for (E contributor : contributors) {
+    public void addAllContributors(Set<Contributor> contributors) {
+        for (Contributor contributor : contributors) {
             map.put(contributor.getName(), contributor);
         }
     }
@@ -39,7 +39,7 @@ class DefaultContributorsSet<E extends Contributor> implements ContributorsSet<E
     }
 
     @Override
-    public Collection<E> getAllContributors() {
+    public Collection<Contributor> getAllContributors() {
         return map.values();
     }
 

--- a/src/main/groovy/org/mockito/release/notes/contributors/DefaultProjectContributor.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/DefaultProjectContributor.java
@@ -1,0 +1,89 @@
+package org.mockito.release.notes.contributors;
+
+import org.json.simple.Jsoner;
+import org.mockito.release.notes.model.ProjectContributor;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class DefaultProjectContributor implements ProjectContributor {
+
+    private static final String jsonFormat = "{ \"name\": \"%s\", \"login\": \"%s\", \"profileUrl\": \"%s\", " +
+            "\"numberOfContributions\": \"%s\" }";
+
+    private final String name;
+    private final String login;
+    private final String profileUrl;
+    private final Integer numberOfContributions;
+
+    DefaultProjectContributor(String name, String login, String profileUrl, Integer numberOfContributions) {
+        this.name = name;
+        this.login = login;
+        this.profileUrl = profileUrl;
+        this.numberOfContributions = numberOfContributions;
+    }
+
+    @Override
+    public int getNumberOfContributions() {
+        return numberOfContributions;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getLogin() {
+        return login;
+    }
+
+    @Override
+    public String getProfileUrl() {
+        return profileUrl;
+    }
+
+    @Override
+    public String toJson() {
+        return String.format(jsonFormat,
+                escapeOrEmpty(name),
+                escape(login),
+                escape(profileUrl),
+                numberOfContributions);
+    }
+
+    private String escapeOrEmpty(String name) {
+        return name != null ? escape(name) : "";
+    }
+
+    private String escape(String login) {
+        return Jsoner.escape(login);
+    }
+
+    @Override
+    public void toJson(Writer writable) throws IOException {
+        writable.append(toJson());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DefaultProjectContributor that = (DefaultProjectContributor) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (!login.equals(that.login)) return false;
+        if (!profileUrl.equals(that.profileUrl)) return false;
+        return numberOfContributions.equals(that.numberOfContributions);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + login.hashCode();
+        result = 31 * result + profileUrl.hashCode();
+        result = 31 * result + numberOfContributions.hashCode();
+        return result;
+    }
+}

--- a/src/main/groovy/org/mockito/release/notes/contributors/DefaultProjectContributorsSet.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/DefaultProjectContributorsSet.java
@@ -1,0 +1,41 @@
+package org.mockito.release.notes.contributors;
+
+import org.mockito.release.notes.model.ProjectContributor;
+
+import java.io.Serializable;
+import java.util.*;
+
+class DefaultProjectContributorsSet implements ProjectContributorsSet, Serializable {
+
+    private final Set<ProjectContributor> contributors;
+
+    DefaultProjectContributorsSet() {
+        contributors = new TreeSet<ProjectContributor>(new Comparator<ProjectContributor>() {
+            @Override
+            public int compare(ProjectContributor o1, ProjectContributor o2) {
+                return o2.getNumberOfContributions() - o1.getNumberOfContributions();   // sort descend
+            }
+        });
+    }
+
+    @Override
+    public void addContributor(ProjectContributor contributorToAdd) {
+        contributors.add(contributorToAdd);
+    }
+
+    @Override
+    public void addAllContributors(Set<ProjectContributor> contributorsToAdd) {
+        contributors.addAll(contributorsToAdd);
+    }
+
+    @Override
+    public int size() {
+        return contributors.size();
+    }
+
+    @Override
+    public Set<ProjectContributor> getAllContributors() {
+        return contributors;
+    }
+
+}

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubAllContributorsFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubAllContributorsFetcher.java
@@ -1,0 +1,89 @@
+package org.mockito.release.notes.contributors;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.json.simple.DeserializationException;
+import org.json.simple.JsonObject;
+import org.mockito.release.notes.model.Contributor;
+import org.mockito.release.notes.util.GitHubListFetcher;
+import org.mockito.release.notes.util.GitHubObjectFetcher;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class GitHubAllContributorsFetcher {
+
+    private static final Logger LOG = Logging.getLogger(GitHubAllContributorsFetcher.class);
+
+    ContributorsSet fetchAllContributorsForProject(String repository, String authToken) {
+        LOG.lifecycle("Querying GitHub API for all contributors for project");
+        ContributorsSet result = new DefaultContributorsSet();
+
+        try {
+            GitHubProjectContributors contributors =
+                    GitHubProjectContributors.authenticatingWith(repository, authToken).build();
+
+            while(contributors.hasNextPage()) {
+                List<JsonObject> page = contributors.nextPage();
+                result.addAllContributors(extractContributors(page, authToken));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
+    private Set<Contributor> extractContributors(List<JsonObject> page, String authToken) throws IOException, DeserializationException {
+        Set<Contributor> result = new HashSet<Contributor>();
+        for (JsonObject contributor : page) {
+            String url = (String) contributor.get("url");
+            GitHubObjectFetcher userFetcher = new GitHubObjectFetcher(url, authToken);
+            JsonObject user = userFetcher.getPage();
+            result.add(GitHubAllContributorsJson.toContributor(contributor, user));
+        }
+        return result;
+    }
+
+    private static class GitHubProjectContributors {
+        private final GitHubListFetcher fetcher;
+        private List<JsonObject> lastFetchedPage;
+
+        static GitHubProjectContributorsBuilder authenticatingWith(String repository, String authToken) {
+            return new GitHubProjectContributorsBuilder(repository, authToken);
+        }
+
+        private GitHubProjectContributors(String nextPageUrl) {
+            fetcher = new GitHubListFetcher(nextPageUrl);
+        }
+
+        public boolean hasNextPage() {
+            return fetcher.hasNextPage();
+        }
+
+        public List<JsonObject> nextPage() throws IOException, DeserializationException {
+            lastFetchedPage = fetcher.nextPage();
+            return lastFetchedPage;
+        }
+    }
+
+    private static class GitHubProjectContributorsBuilder {
+
+        private final String repository;
+        private final String authToken;
+
+        public GitHubProjectContributorsBuilder(String repository, String authToken) {
+            this.repository = repository;
+            this.authToken = authToken;
+        }
+
+        GitHubProjectContributors build() {
+            // see API doc: https://developer.github.com/v3/repos/#list-contributors
+            String nextPageUrl = String.format("%s%s",
+                    "https://api.github.com/repos/" + repository + "/contributors",
+                    "?access_token=" + authToken);
+            return new GitHubProjectContributors(nextPageUrl);
+        }
+    }
+}

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubAllContributorsFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubAllContributorsFetcher.java
@@ -4,7 +4,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.json.simple.DeserializationException;
 import org.json.simple.JsonObject;
-import org.mockito.release.notes.model.Contributor;
+import org.mockito.release.notes.model.ProjectContributor;
 import org.mockito.release.notes.util.GitHubListFetcher;
 import org.mockito.release.notes.util.GitHubObjectFetcher;
 
@@ -17,9 +17,9 @@ public class GitHubAllContributorsFetcher {
 
     private static final Logger LOG = Logging.getLogger(GitHubAllContributorsFetcher.class);
 
-    ContributorsSet fetchAllContributorsForProject(String repository, String authToken) {
+    ProjectContributorsSet fetchAllContributorsForProject(String repository, String authToken) {
         LOG.lifecycle("Querying GitHub API for all contributors for project");
-        ContributorsSet result = new DefaultContributorsSet();
+        ProjectContributorsSet result = new DefaultProjectContributorsSet();
 
         try {
             GitHubProjectContributors contributors =
@@ -35,8 +35,8 @@ public class GitHubAllContributorsFetcher {
         return result;
     }
 
-    private Set<Contributor> extractContributors(List<JsonObject> page, String authToken) throws IOException, DeserializationException {
-        Set<Contributor> result = new HashSet<Contributor>();
+    private Set<ProjectContributor> extractContributors(List<JsonObject> page, String authToken) throws IOException, DeserializationException {
+        Set<ProjectContributor> result = new HashSet<ProjectContributor>();
         for (JsonObject contributor : page) {
             String url = (String) contributor.get("url");
             GitHubObjectFetcher userFetcher = new GitHubObjectFetcher(url, authToken);

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubAllContributorsJson.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubAllContributorsJson.java
@@ -1,0 +1,28 @@
+package org.mockito.release.notes.contributors;
+
+import org.json.simple.JsonObject;
+import org.mockito.release.notes.model.ProjectContributor;
+
+/**
+ * Provides means to parse JsonObjects returned from calling GitHub API.
+ */
+public class GitHubAllContributorsJson {
+
+    /**
+     * Parses GitHub JsonObject in accordance to the API
+     * @param contributor Represent project contribution: https://developer.github.com/v3/repos/#list-contributors and
+     * @param user Represent user: https://developer.github.com/v3/users/#get-a-single-user
+     * @return Contributor object based on project contribution and user
+     */
+    public static ProjectContributor toContributor(JsonObject contributor, JsonObject user) {
+        String name = user.getString("name");
+        String login = user.getString("login");
+        String profileUrl = contributor.getString("html_url");
+        Integer numberOfContributors = contributor.getInteger("contributions");
+        return new DefaultProjectContributor(textOrEmpty(name), login, profileUrl, numberOfContributors);
+    }
+
+    private static String textOrEmpty(String text) {
+        return text != null ? text : "";
+    }
+}

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsProvider.java
@@ -9,21 +9,21 @@ public class GitHubContributorsProvider implements ContributorsProvider {
     private static final Logger LOG = Logging.getLogger(GitHubContributorsProvider.class);
 
     private final String repository;
-    private final String authToken;
+    private final String readOnlyAuthToken;
 
-    GitHubContributorsProvider(String repository, String authToken) {
+    GitHubContributorsProvider(String repository, String readOnlyAuthToken) {
         this.repository = repository;
-        this.authToken = authToken;
+        this.readOnlyAuthToken = readOnlyAuthToken;
     }
 
     @Override
     public ContributorsSet mapContributorsToGitHubUser(ContributionSet contributions, String fromRevision, String toRevision) {
         LOG.info("Parsing {} commits with {} contributors", contributions.getAllCommits().size(), contributions.getAuthorCount());
-        return new GitHubLastContributorsFetcher().fetchContributors(repository, authToken, contributions.getContributions(), fromRevision, toRevision);
+        return new GitHubLastContributorsFetcher().fetchContributors(repository, readOnlyAuthToken, contributions.getContributions(), fromRevision, toRevision);
     }
 
     @Override
     public ProjectContributorsSet getAllContributorsForProject() {
-        return new GitHubAllContributorsFetcher().fetchAllContributorsForProject(repository, authToken);
+        return new GitHubAllContributorsFetcher().fetchAllContributorsForProject(repository, readOnlyAuthToken);
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsProvider.java
@@ -23,7 +23,7 @@ public class GitHubContributorsProvider implements ContributorsProvider {
     }
 
     @Override
-    public ContributorsSet getAllContributorsForProject() {
+    public ProjectContributorsSet getAllContributorsForProject() {
         return new GitHubAllContributorsFetcher().fetchAllContributorsForProject(repository, authToken);
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubContributorsProvider.java
@@ -1,12 +1,13 @@
 package org.mockito.release.notes.contributors;
 
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.mockito.release.notes.model.ContributionSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class GitHubContributorsProvider implements ContributorsProvider {
 
-    private static final Logger LOG = LoggerFactory.getLogger(GitHubContributorsProvider.class);
+    private static final Logger LOG = Logging.getLogger(GitHubContributorsProvider.class);
+
     private final String repository;
     private final String authToken;
 
@@ -18,6 +19,11 @@ public class GitHubContributorsProvider implements ContributorsProvider {
     @Override
     public ContributorsSet mapContributorsToGitHubUser(ContributionSet contributions, String fromRevision, String toRevision) {
         LOG.info("Parsing {} commits with {} contributors", contributions.getAllCommits().size(), contributions.getAuthorCount());
-        return new GitHubContributorsFetcher().fetchContributors(repository, authToken, contributions.getContributions(), fromRevision, toRevision);
+        return new GitHubLastContributorsFetcher().fetchContributors(repository, authToken, contributions.getContributions(), fromRevision, toRevision);
+    }
+
+    @Override
+    public ContributorsSet getAllContributorsForProject() {
+        return new GitHubAllContributorsFetcher().fetchAllContributorsForProject(repository, authToken);
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubLastContributorsFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubLastContributorsFetcher.java
@@ -1,24 +1,24 @@
 package org.mockito.release.notes.contributors;
 
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.json.simple.DeserializationException;
 import org.json.simple.JsonObject;
 import org.mockito.release.notes.model.Commit;
 import org.mockito.release.notes.model.Contribution;
 import org.mockito.release.notes.model.Contributor;
-import org.mockito.release.notes.util.GitHubFetcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.mockito.release.notes.util.GitHubListFetcher;
 
 import java.io.IOException;
 import java.util.*;
 
-public class GitHubContributorsFetcher {
+public class GitHubLastContributorsFetcher {
 
-    private static final Logger LOG = LoggerFactory.getLogger(GitHubContributorsFetcher.class);
+    private static final Logger LOG = Logging.getLogger(GitHubLastContributorsFetcher.class);
 
     ContributorsSet fetchContributors(String repository, String authToken, Collection<Contribution> contributions, String fromRevision, String toRevision) {
-        ContributorsSet result = new DefaultContributorsSet();
         LOG.info("Querying GitHub API for commits (for contributors)");
+        ContributorsSet result = new DefaultContributorsSet();
 
         Set<String> authors = getAuthors(contributions);
 
@@ -112,11 +112,11 @@ public class GitHubContributorsFetcher {
     private static class GitHubCommits {
 
         private final String fromRevision;
-        private final GitHubFetcher fetcher;
+        private final GitHubListFetcher fetcher;
         private List<JsonObject> lastFetchedPage;
 
         private GitHubCommits(String nextPageUrl, String fromRevision) {
-            fetcher = new GitHubFetcher(nextPageUrl);
+            fetcher = new GitHubListFetcher(nextPageUrl);
             this.fromRevision = fromRevision;
         }
 

--- a/src/main/groovy/org/mockito/release/notes/contributors/GitHubLastContributorsFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/GitHubLastContributorsFetcher.java
@@ -16,14 +16,14 @@ public class GitHubLastContributorsFetcher {
 
     private static final Logger LOG = Logging.getLogger(GitHubLastContributorsFetcher.class);
 
-    ContributorsSet fetchContributors(String repository, String authToken, Collection<Contribution> contributions, String fromRevision, String toRevision) {
+    ContributorsSet fetchContributors(String repository, String readOnlyAuthToken, Collection<Contribution> contributions, String fromRevision, String toRevision) {
         LOG.info("Querying GitHub API for commits (for contributors)");
         ContributorsSet result = new DefaultContributorsSet();
 
         Set<String> authors = getAuthors(contributions);
 
         try {
-            GitHubCommits commits = GitHubCommits.authenticatingWith(repository, authToken)
+            GitHubCommits commits = GitHubCommits.authenticatingWith(repository, readOnlyAuthToken)
                     .fromRevision(fromRevision)
                     .toRevision(toRevision)
                     .build();
@@ -141,19 +141,19 @@ public class GitHubLastContributorsFetcher {
             return lastFetchedPage;
         }
 
-        static GitHubCommitsBuilder authenticatingWith(String repository, String authToken) {
-            return new GitHubCommitsBuilder(repository, authToken);
+        static GitHubCommitsBuilder authenticatingWith(String repository, String readOnlyAuthToken) {
+            return new GitHubCommitsBuilder(repository, readOnlyAuthToken);
         }
 
         private static class GitHubCommitsBuilder {
             private final String repository;
-            private final String authToken;
+            private final String readOnlyAuthToken;
             private String fromRevision;
             private String toRevision;
 
-            private GitHubCommitsBuilder(String repository, String authToken) {
+            private GitHubCommitsBuilder(String repository, String readOnlyAuthToken) {
                 this.repository = repository;
-                this.authToken = authToken;
+                this.readOnlyAuthToken = readOnlyAuthToken;
             }
 
             GitHubCommitsBuilder fromRevision(String fromRevision) {
@@ -170,7 +170,7 @@ public class GitHubLastContributorsFetcher {
                 // see API doc: https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
                 String nextPageUrl = String.format("%s%s%s%s",
                         "https://api.github.com/repos/" + repository + "/commits",
-                        "?access_token=" + authToken,
+                        "?access_token=" + readOnlyAuthToken,
                         max(toRevision),
                         "&page=1");
                 return new GitHubCommits(nextPageUrl, fromRevision);

--- a/src/main/groovy/org/mockito/release/notes/contributors/ProjectContributorsSet.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/ProjectContributorsSet.java
@@ -1,0 +1,17 @@
+package org.mockito.release.notes.contributors;
+
+import org.mockito.release.notes.model.ProjectContributor;
+
+import java.util.Set;
+
+public interface ProjectContributorsSet {
+
+    void addContributor(ProjectContributor contributor);
+
+    void addAllContributors(Set<ProjectContributor> projectContributors);
+
+    int size();
+
+    Set<ProjectContributor> getAllContributors();
+
+}

--- a/src/main/groovy/org/mockito/release/notes/generator/ReleaseNotesGenerators.java
+++ b/src/main/groovy/org/mockito/release/notes/generator/ReleaseNotesGenerators.java
@@ -16,12 +16,12 @@ public class ReleaseNotesGenerators {
 
     //TODO move entire "org.mockito.release.notes" -> "org.mockito.release.internal.notes"
 
-    public static ReleaseNotesGenerator releaseNotesGenerator(File workDir, String repository, String authToken) {
+    public static ReleaseNotesGenerator releaseNotesGenerator(File workDir, String repository, String readOnlyAuthToken) {
         ProcessRunner processRunner = Exec.getProcessRunner(workDir);
         ContributionsProvider contributionsProvider = Vcs.getContributionsProvider(processRunner);
-        ImprovementsProvider improvementsProvider = Improvements.getGitHubProvider(repository, authToken);
+        ImprovementsProvider improvementsProvider = Improvements.getGitHubProvider(repository, readOnlyAuthToken);
         ReleasedVersionsProvider releasedVersionsProvider = Vcs.getReleaseDateProvider(processRunner);
-        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, authToken);
+        GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContibutorsProvider(repository, readOnlyAuthToken);
         return new DefaultReleaseNotesGenerator(contributionsProvider, improvementsProvider, releasedVersionsProvider,
                 contributorsProvider);
     }

--- a/src/main/groovy/org/mockito/release/notes/improvements/GitHubImprovementsProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/improvements/GitHubImprovementsProvider.java
@@ -10,16 +10,16 @@ import java.util.Collection;
 class GitHubImprovementsProvider implements ImprovementsProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(GitHubImprovementsProvider.class);
-    private final String authToken;
+    private final String readOnlyAuthToken;
     private final String repository;
 
-    GitHubImprovementsProvider(String repository, String authToken) {
+    GitHubImprovementsProvider(String repository, String readOnlyAuthToken) {
         this.repository = repository;
-        this.authToken = authToken;
+        this.readOnlyAuthToken = readOnlyAuthToken;
     }
 
     public Collection<Improvement> getImprovements(ContributionSet contributions, Collection<String> labels, boolean onlyPullRequests) {
         LOG.info("Parsing {} commits with {} tickets", contributions.getAllCommits().size(), contributions.getAllTickets().size());
-        return new GitHubTicketFetcher().fetchTickets(repository, authToken, contributions.getAllTickets(), labels, onlyPullRequests);
+        return new GitHubTicketFetcher().fetchTickets(repository, readOnlyAuthToken, contributions.getAllTickets(), labels, onlyPullRequests);
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
@@ -15,7 +15,7 @@ class GitHubTicketFetcher {
 
     private static final Logger LOG = LoggerFactory.getLogger(GitHubTicketFetcher.class);
 
-    Collection<Improvement> fetchTickets(String repository, String authToken, Collection<String> ticketIds, Collection<String> labels,
+    Collection<Improvement> fetchTickets(String repository, String readOnlyAuthToken, Collection<String> ticketIds, Collection<String> labels,
                                          boolean onlyPullRequests) {
         List<Improvement> out = new LinkedList<Improvement>();
         if (ticketIds.isEmpty()) {
@@ -26,7 +26,7 @@ class GitHubTicketFetcher {
         Queue<Long> tickets = queuedTicketNumbers(ticketIds);
 
         try {
-            GitHubIssues issues = GitHubIssues.forRepo(repository, authToken)
+            GitHubIssues issues = GitHubIssues.forRepo(repository, readOnlyAuthToken)
                     .state("closed")
                     .labels(CommaSeparated.commaSeparated(labels))
                     .filter("all")
@@ -106,21 +106,21 @@ class GitHubTicketFetcher {
             return fetcher.nextPage();
         }
 
-        static GitHubIssuesBuilder forRepo(String repository, String authToken) {
-            return new GitHubIssuesBuilder(repository, authToken);
+        static GitHubIssuesBuilder forRepo(String repository, String readOnlyAuthToken) {
+            return new GitHubIssuesBuilder(repository, readOnlyAuthToken);
         }
 
         private static class GitHubIssuesBuilder {
-            private final String authToken;
+            private final String readOnlyAuthToken;
             private final String repository;
             private String state;
             private String filter;
             private String direction;
             private String labels;
 
-            GitHubIssuesBuilder(String repository, String authToken) {
+            GitHubIssuesBuilder(String repository, String readOnlyAuthToken) {
                 this.repository = repository;
-                this.authToken = authToken;
+                this.readOnlyAuthToken = readOnlyAuthToken;
             }
 
             GitHubIssuesBuilder state(String state) {
@@ -151,7 +151,7 @@ class GitHubTicketFetcher {
                 // see API doc: https://developer.github.com/v3/issues/
                 String nextPageUrl = String.format("%s%s%s%s%s%s%s",
                         "https://api.github.com/repos/" + repository + "/issues",
-                        "?access_token=" + authToken,
+                        "?access_token=" + readOnlyAuthToken,
                         state == null ? "" : "&state=" + state,
                         filter == null ? "" : "&filter=" + filter,
                         "&labels=" + labels,

--- a/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
@@ -3,7 +3,7 @@ package org.mockito.release.notes.improvements;
 import org.json.simple.DeserializationException;
 import org.json.simple.JsonObject;
 import org.mockito.release.notes.model.Improvement;
-import org.mockito.release.notes.util.GitHubFetcher;
+import org.mockito.release.notes.util.GitHubListFetcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,10 +92,10 @@ class GitHubTicketFetcher {
 
     private static class GitHubIssues {
 
-        private final GitHubFetcher fetcher;
+        private final GitHubListFetcher fetcher;
 
         private GitHubIssues(String nextPageUrl) {
-            fetcher = new GitHubFetcher(nextPageUrl);
+            fetcher = new GitHubListFetcher(nextPageUrl);
         }
 
         boolean hasNextPage() {

--- a/src/main/groovy/org/mockito/release/notes/improvements/Improvements.java
+++ b/src/main/groovy/org/mockito/release/notes/improvements/Improvements.java
@@ -9,9 +9,9 @@ public class Improvements {
      * Fetches tickets from GitHub. Needs GitHub auth token.
      *
      * @param repository the repository in format USER|COMPANY/REPO_NAME, for example: mockito/mockito
-     * @param authToken the GitHub auth token
+     * @param readOnlyAuthToken the GitHub auth token
      */
-    public static ImprovementsProvider getGitHubProvider(String repository, final String authToken) {
-        return new GitHubImprovementsProvider(repository, authToken);
+    public static ImprovementsProvider getGitHubProvider(String repository, final String readOnlyAuthToken) {
+        return new GitHubImprovementsProvider(repository, readOnlyAuthToken);
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/model/ProjectContributor.java
+++ b/src/main/groovy/org/mockito/release/notes/model/ProjectContributor.java
@@ -1,0 +1,6 @@
+package org.mockito.release.notes.model;
+
+public interface ProjectContributor extends Contributor {
+
+    int getNumberOfContributions();
+}

--- a/src/main/groovy/org/mockito/release/notes/util/GitHubListFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/util/GitHubListFetcher.java
@@ -1,11 +1,12 @@
 package org.mockito.release.notes.util;
 
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.json.simple.DeserializationException;
 import org.json.simple.JsonObject;
 import org.json.simple.Jsoner;
 import org.mockito.release.notes.internal.DateFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,19 +18,19 @@ import java.util.List;
 /**
  * This class contains standard operations for skim over GitHub API responses.
  */
-public class GitHubFetcher {
+public class GitHubListFetcher {
 
-    private static final Logger LOG = LoggerFactory.getLogger(GitHubFetcher.class);
+    private static final Logger LOG = Logging.getLogger(GitHubListFetcher.class);
 
     private static final String RELATIVE_LINK_NOT_FOUND = "none";
     private String nextPageUrl;
 
-    public GitHubFetcher(String nextPageUrl) {
+    public GitHubListFetcher(String nextPageUrl) {
         this.nextPageUrl = nextPageUrl;
     }
 
     //TODO SF is this method needed? It's never used
-    public GitHubFetcher init() throws IOException {
+    public GitHubListFetcher init() throws IOException {
         URLConnection urlConnection = new URL(nextPageUrl).openConnection();
         nextPageUrl = extractRelativeLink(urlConnection.getHeaderField("Link"), "next");
         return this;
@@ -44,7 +45,7 @@ public class GitHubFetcher {
             throw new IllegalStateException("GitHub API no more issues to fetch");
         }
         URL url = new URL(nextPageUrl);
-        LOG.info("GitHub API querying issue page {}", queryParamValue(url, "page"));
+        LOG.info("GitHub API querying page {}", queryParamValue(url, "page"));
         URLConnection urlConnection = url.openConnection();
 
         Date resetInEpochSeconds = DateFormat.parseDateInEpochSeconds(urlConnection.getHeaderField("X-RateLimit-Reset"));
@@ -53,8 +54,7 @@ public class GitHubFetcher {
         LOG.info("GitHub API rate info => Remaining : {}, Limit : {}, Reset at: {}",
                 urlConnection.getHeaderField("X-RateLimit-Remaining"),
                 urlConnection.getHeaderField("X-RateLimit-Limit"),
-                resetInLocalTime
-        );
+                resetInLocalTime);
         nextPageUrl = extractRelativeLink(urlConnection.getHeaderField("Link"), "next");
 
         return parseJsonFrom(urlConnection);
@@ -77,7 +77,7 @@ public class GitHubFetcher {
         LOG.info("GitHub API responded successfully.");
         @SuppressWarnings("unchecked")
         List<JsonObject> issues = (List<JsonObject>) Jsoner.deserialize(content);
-        LOG.info("GitHub API returned {} issues.", issues.size());
+        LOG.info("GitHub API returned {} Json objects.", issues.size());
         return issues;
     }
 

--- a/src/main/groovy/org/mockito/release/notes/util/GitHubListFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/util/GitHubListFetcher.java
@@ -48,8 +48,7 @@ public class GitHubListFetcher {
         LOG.info("GitHub API querying page {}", queryParamValue(url, "page"));
         URLConnection urlConnection = url.openConnection();
 
-        Date resetInEpochSeconds = DateFormat.parseDateInEpochSeconds(urlConnection.getHeaderField("X-RateLimit-Reset"));
-        String resetInLocalTime = DateFormat.formatDateToLocalTime(resetInEpochSeconds);
+        String resetInLocalTime = resetLimitInLocalTimeOrEmpty(urlConnection);
 
         LOG.info("GitHub API rate info => Remaining : {}, Limit : {}, Reset at: {}",
                 urlConnection.getHeaderField("X-RateLimit-Remaining"),
@@ -58,6 +57,15 @@ public class GitHubListFetcher {
         nextPageUrl = extractRelativeLink(urlConnection.getHeaderField("Link"), "next");
 
         return parseJsonFrom(urlConnection);
+    }
+
+    private String resetLimitInLocalTimeOrEmpty(URLConnection urlConnection) {
+        String rateLimitReset = urlConnection.getHeaderField("X-RateLimit-Reset");
+        if(rateLimitReset == null) {
+            return "";
+        }
+        Date resetInEpochSeconds = DateFormat.parseDateInEpochSeconds(rateLimitReset);
+        return DateFormat.formatDateToLocalTime(resetInEpochSeconds);
     }
 
     private String queryParamValue(URL url, String page) {

--- a/src/main/groovy/org/mockito/release/notes/util/GitHubObjectFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/util/GitHubObjectFetcher.java
@@ -7,8 +7,7 @@ import org.json.simple.JsonObject;
 import org.json.simple.Jsoner;
 import org.mockito.release.notes.internal.DateFormat;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Date;
@@ -35,8 +34,7 @@ public class GitHubObjectFetcher {
 
         URLConnection urlConnection = url.openConnection();
 
-        Date resetInEpochSeconds = DateFormat.parseDateInEpochSeconds(urlConnection.getHeaderField("X-RateLimit-Reset"));
-        String resetInLocalTime = DateFormat.formatDateToLocalTime(resetInEpochSeconds);
+        String resetInLocalTime = resetLimitInLocalTimeOrEmpty(urlConnection);
 
         LOG.info("GitHub API rate info => Remaining : {}, Limit : {}, Reset at: {}",
                 urlConnection.getHeaderField("X-RateLimit-Remaining"),
@@ -44,6 +42,15 @@ public class GitHubObjectFetcher {
                 resetInLocalTime);
 
         return parseJsonFrom(urlConnection);
+    }
+
+    private String resetLimitInLocalTimeOrEmpty(URLConnection urlConnection) {
+        String rateLimitReset = urlConnection.getHeaderField("X-RateLimit-Reset");
+        if(rateLimitReset == null) {
+            return "";
+        }
+        Date resetInEpochSeconds = DateFormat.parseDateInEpochSeconds(rateLimitReset);
+        return DateFormat.formatDateToLocalTime(resetInEpochSeconds);
     }
 
     private JsonObject parseJsonFrom(URLConnection urlConnection) throws IOException, DeserializationException {

--- a/src/main/groovy/org/mockito/release/notes/util/GitHubObjectFetcher.java
+++ b/src/main/groovy/org/mockito/release/notes/util/GitHubObjectFetcher.java
@@ -1,0 +1,57 @@
+package org.mockito.release.notes.util;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.json.simple.DeserializationException;
+import org.json.simple.JsonObject;
+import org.json.simple.Jsoner;
+import org.mockito.release.notes.internal.DateFormat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Date;
+
+/**
+ * This class contains a standerd operation for fetching single page for GitHub.
+ */
+public class GitHubObjectFetcher {
+
+    private static final Logger LOG = Logging.getLogger(GitHubObjectFetcher.class);
+
+
+    private final String pageUrl;
+    private final String authToken;
+
+    public GitHubObjectFetcher(String pageUrl, String authToken) {
+        this.pageUrl = pageUrl;
+        this.authToken = authToken;
+    }
+
+    public JsonObject getPage() throws IOException, DeserializationException {
+        URL url = new URL(String.format("%s%s%s", pageUrl, "?access_token=", authToken));
+        LOG.info("GitHub API querying page {}", url);
+
+        URLConnection urlConnection = url.openConnection();
+
+        Date resetInEpochSeconds = DateFormat.parseDateInEpochSeconds(urlConnection.getHeaderField("X-RateLimit-Reset"));
+        String resetInLocalTime = DateFormat.formatDateToLocalTime(resetInEpochSeconds);
+
+        LOG.info("GitHub API rate info => Remaining : {}, Limit : {}, Reset at: {}",
+                urlConnection.getHeaderField("X-RateLimit-Remaining"),
+                urlConnection.getHeaderField("X-RateLimit-Limit"),
+                resetInLocalTime);
+
+        return parseJsonFrom(urlConnection);
+    }
+
+    private JsonObject parseJsonFrom(URLConnection urlConnection) throws IOException, DeserializationException {
+        InputStream response = urlConnection.getInputStream();
+
+        String content = IOUtil.readFully(response);
+        LOG.info("GitHub API responded successfully.");
+
+        return (JsonObject) Jsoner.deserialize(content);
+    }
+}

--- a/src/main/groovy/org/mockito/release/notes/util/IOUtil.java
+++ b/src/main/groovy/org/mockito/release/notes/util/IOUtil.java
@@ -46,7 +46,7 @@ public class IOUtil {
     }
 
     private static String readNow(InputStream is) {
-        Scanner s = new Scanner(is).useDelimiter("\\A");
+        Scanner s = new Scanner(is, "UTF-8").useDelimiter("\\A");
         try {
             return s.hasNext() ? s.next() : "";
         } finally {
@@ -58,7 +58,7 @@ public class IOUtil {
         PrintWriter p = null;
         try {
             target.getParentFile().mkdirs();
-            p = new PrintWriter(new FileWriter(target));
+            p = new PrintWriter(new OutputStreamWriter(new FileOutputStream(target), "UTF-8"));
             p.write(content);
         } catch (Exception e) {
             throw new RuntimeException("Problems writing text to file: " + target);

--- a/src/main/groovy/org/mockito/release/notes/vcs/ContributionsProvider.java
+++ b/src/main/groovy/org/mockito/release/notes/vcs/ContributionsProvider.java
@@ -8,7 +8,7 @@ import org.mockito.release.notes.model.ContributionSet;
 public interface ContributionsProvider {
 
     /**
-     * Provides contributions between specified versions
+     * Provides contributions between specified revisions
      */
     ContributionSet getContributionsBetween(String fromRev, String toRev);
 }

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPluginTest.groovy
@@ -28,4 +28,20 @@ class ReleaseConfigurationPluginTest extends Specification {
         expect:
         root.plugins.apply(ReleaseConfigurationPlugin).configuration.dryRun
     }
+
+    def "should set team.addContributorsToPomFromGitHub to true by default"() {
+        expect:
+        root.plugins.apply(ReleaseConfigurationPlugin).configuration.team.addContributorsToPomFromGitHub == true
+    }
+
+    def "should team.addContributorsToPomFromGitHub be false when set to false"() {
+        when:
+        def configuration = root.plugins.apply(ReleaseConfigurationPlugin).configuration
+        configuration.team.addContributorsToPomFromGitHub = false
+
+        then:
+        configuration.team.addContributorsToPomFromGitHub == false
+    }
+
+
 }

--- a/src/test/groovy/org/mockito/release/notes/contributors/AllContributorsSerializerTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/AllContributorsSerializerTest.groovy
@@ -1,6 +1,5 @@
 package org.mockito.release.notes.contributors
 
-import org.mockito.release.notes.model.ProjectContributor
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -16,7 +15,7 @@ class AllContributorsSerializerTest extends Specification {
 
         when:
         serializer.serialize(contributors)
-        def actual = serializer.desrialize()
+        def actual = serializer.deserialize()
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -28,7 +27,7 @@ class AllContributorsSerializerTest extends Specification {
 
         when:
         serializer.serialize(contributors)
-        def actual = serializer.desrialize()
+        def actual = serializer.deserialize()
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -45,29 +44,7 @@ class AllContributorsSerializerTest extends Specification {
 
         when:
         serializer.serialize(contributors)
-        def actual = serializer.desrialize()
-
-        then:
-        actual.getAllContributors().containsAll(contributors.getAllContributors())
-        contributors.getAllContributors().containsAll(actual.getAllContributors())
-    }
-
-    def "serialization and deserialization of 5 contributors"() {
-        def contributors = new DefaultProjectContributorsSet()
-        def contributor1 = new DefaultProjectContributor("myName 1", "myLogin 1", "myProfileUrl 1", 5)
-        def contributor2 = new DefaultProjectContributor("myName 2", "myLogin 2", "myProfileUrl 2", 6)
-        def contributor3 = new DefaultProjectContributor("myName 3", "myLogin 3", "myProfileUrl 3", 7)
-        def contributor4 = new DefaultProjectContributor("myName 4", "myLogin 4", "myProfileUrl 4", 8)
-        def contributor5 = new DefaultProjectContributor("myName 5", "myLogin 5", "myProfileUrl 5", 9)
-        contributors.addContributor(contributor1)
-        contributors.addContributor(contributor2)
-        contributors.addContributor(contributor3)
-        contributors.addContributor(contributor4)
-        contributors.addContributor(contributor5)
-
-        when:
-        serializer.serialize(contributors)
-        def actual = serializer.desrialize()
+        def actual = serializer.deserialize()
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -81,7 +58,7 @@ class AllContributorsSerializerTest extends Specification {
 
         when:
         serializer.serialize(contributors)
-        def actual = serializer.desrialize()
+        def actual = serializer.deserialize()
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -95,7 +72,7 @@ class AllContributorsSerializerTest extends Specification {
 
         when:
         serializer.serialize(contributors)
-        def actual = serializer.desrialize()
+        def actual = serializer.deserialize()
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -109,7 +86,7 @@ class AllContributorsSerializerTest extends Specification {
 
         when:
         serializer.serialize(contributors)
-        def actual = serializer.desrialize()
+        def actual = serializer.deserialize()
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())

--- a/src/test/groovy/org/mockito/release/notes/contributors/AllContributorsSerializerTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/AllContributorsSerializerTest.groovy
@@ -10,7 +10,7 @@ class AllContributorsSerializerTest extends Specification {
     @Subject serializer = new AllContributorsSerializer(tempFile)
 
     def "serialization and deserialization of one contributor"() {
-        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributors = new DefaultProjectContributorsSet()
         def contributor = new DefaultProjectContributor("myName", "myLogin", "myProfileUrl", 5)
         contributors.addContributor(contributor)
 
@@ -24,7 +24,7 @@ class AllContributorsSerializerTest extends Specification {
     }
 
     def "serialization and deserialization of zero contributor"() {
-        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributors = new DefaultProjectContributorsSet()
 
         when:
         serializer.serialize(contributors)
@@ -37,7 +37,7 @@ class AllContributorsSerializerTest extends Specification {
     }
 
     def "serialization and deserialization of two contributors"() {
-        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributors = new DefaultProjectContributorsSet()
         def contributor1 = new DefaultProjectContributor("myName 1", "myLogin 1", "myProfileUrl 1", 5)
         def contributor2 = new DefaultProjectContributor("myName 2", "myLogin 2", "myProfileUrl 2", 5)
         contributors.addContributor(contributor1)
@@ -53,7 +53,7 @@ class AllContributorsSerializerTest extends Specification {
     }
 
     def "serialization and deserialization of 5 contributors"() {
-        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributors = new DefaultProjectContributorsSet()
         def contributor1 = new DefaultProjectContributor("myName 1", "myLogin 1", "myProfileUrl 1", 5)
         def contributor2 = new DefaultProjectContributor("myName 2", "myLogin 2", "myProfileUrl 2", 6)
         def contributor3 = new DefaultProjectContributor("myName 3", "myLogin 3", "myProfileUrl 3", 7)
@@ -75,7 +75,7 @@ class AllContributorsSerializerTest extends Specification {
     }
 
     def "serialization and deserialization contributor with special characters"() {
-        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributors = new DefaultProjectContributorsSet()
         def contributor = new DefaultProjectContributor("my\"Na\\m\fe ", "my\rLo\bg\ni\tn", "\u0000myP\u001Fro\u007Ffi\u009FleUrl ", 5)
         contributors.addContributor(contributor)
 
@@ -89,7 +89,7 @@ class AllContributorsSerializerTest extends Specification {
     }
 
     def "serialization and deserialization contributor with emty name"() {
-        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributors = new DefaultProjectContributorsSet()
         def contributor = new DefaultProjectContributor("", "myLogin", "myProfileUrl", 5)
         contributors.addContributor(contributor)
 
@@ -103,7 +103,7 @@ class AllContributorsSerializerTest extends Specification {
     }
 
     def "serialization and deserialization contributor with zero contributions"() {
-        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributors = new DefaultProjectContributorsSet()
         def contributor = new DefaultProjectContributor("myName", "myLogin", "myProfileUrl", 0)
         contributors.addContributor(contributor)
 

--- a/src/test/groovy/org/mockito/release/notes/contributors/AllContributorsSerializerTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/AllContributorsSerializerTest.groovy
@@ -1,0 +1,118 @@
+package org.mockito.release.notes.contributors
+
+import org.mockito.release.notes.model.ProjectContributor
+import spock.lang.Specification
+import spock.lang.Subject
+
+class AllContributorsSerializerTest extends Specification {
+
+    private File tempFile = new File(System.getProperty("java.io.tmpdir") + "/project-contributors.json")
+    @Subject serializer = new AllContributorsSerializer(tempFile)
+
+    def "serialization and deserialization of one contributor"() {
+        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributor = new DefaultProjectContributor("myName", "myLogin", "myProfileUrl", 5)
+        contributors.addContributor(contributor)
+
+        when:
+        serializer.serialize(contributors)
+        def actual = serializer.desrialize()
+
+        then:
+        actual.getAllContributors().containsAll(contributors.getAllContributors())
+        contributors.getAllContributors().containsAll(actual.getAllContributors())
+    }
+
+    def "serialization and deserialization of zero contributor"() {
+        def contributors = new DefaultContributorsSet<ProjectContributor>()
+
+        when:
+        serializer.serialize(contributors)
+        def actual = serializer.desrialize()
+
+        then:
+        actual.getAllContributors().containsAll(contributors.getAllContributors())
+        contributors.getAllContributors().containsAll(actual.getAllContributors())
+        actual.size() == 0
+    }
+
+    def "serialization and deserialization of two contributors"() {
+        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributor1 = new DefaultProjectContributor("myName 1", "myLogin 1", "myProfileUrl 1", 5)
+        def contributor2 = new DefaultProjectContributor("myName 2", "myLogin 2", "myProfileUrl 2", 5)
+        contributors.addContributor(contributor1)
+        contributors.addContributor(contributor2)
+
+        when:
+        serializer.serialize(contributors)
+        def actual = serializer.desrialize()
+
+        then:
+        actual.getAllContributors().containsAll(contributors.getAllContributors())
+        contributors.getAllContributors().containsAll(actual.getAllContributors())
+    }
+
+    def "serialization and deserialization of 5 contributors"() {
+        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributor1 = new DefaultProjectContributor("myName 1", "myLogin 1", "myProfileUrl 1", 5)
+        def contributor2 = new DefaultProjectContributor("myName 2", "myLogin 2", "myProfileUrl 2", 6)
+        def contributor3 = new DefaultProjectContributor("myName 3", "myLogin 3", "myProfileUrl 3", 7)
+        def contributor4 = new DefaultProjectContributor("myName 4", "myLogin 4", "myProfileUrl 4", 8)
+        def contributor5 = new DefaultProjectContributor("myName 5", "myLogin 5", "myProfileUrl 5", 9)
+        contributors.addContributor(contributor1)
+        contributors.addContributor(contributor2)
+        contributors.addContributor(contributor3)
+        contributors.addContributor(contributor4)
+        contributors.addContributor(contributor5)
+
+        when:
+        serializer.serialize(contributors)
+        def actual = serializer.desrialize()
+
+        then:
+        actual.getAllContributors().containsAll(contributors.getAllContributors())
+        contributors.getAllContributors().containsAll(actual.getAllContributors())
+    }
+
+    def "serialization and deserialization contributor with special characters"() {
+        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributor = new DefaultProjectContributor("my\"Na\\m\fe ", "my\rLo\bg\ni\tn", "\u0000myP\u001Fro\u007Ffi\u009FleUrl ", 5)
+        contributors.addContributor(contributor)
+
+        when:
+        serializer.serialize(contributors)
+        def actual = serializer.desrialize()
+
+        then:
+        actual.getAllContributors().containsAll(contributors.getAllContributors())
+        contributors.getAllContributors().containsAll(actual.getAllContributors())
+    }
+
+    def "serialization and deserialization contributor with emty name"() {
+        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributor = new DefaultProjectContributor("", "myLogin", "myProfileUrl", 5)
+        contributors.addContributor(contributor)
+
+        when:
+        serializer.serialize(contributors)
+        def actual = serializer.desrialize()
+
+        then:
+        actual.getAllContributors().containsAll(contributors.getAllContributors())
+        contributors.getAllContributors().containsAll(actual.getAllContributors())
+    }
+
+    def "serialization and deserialization contributor with zero contributions"() {
+        def contributors = new DefaultContributorsSet<ProjectContributor>()
+        def contributor = new DefaultProjectContributor("myName", "myLogin", "myProfileUrl", 0)
+        contributors.addContributor(contributor)
+
+        when:
+        serializer.serialize(contributors)
+        def actual = serializer.desrialize()
+
+        then:
+        actual.getAllContributors().containsAll(contributors.getAllContributors())
+        contributors.getAllContributors().containsAll(actual.getAllContributors())
+    }
+}

--- a/src/test/groovy/org/mockito/release/notes/contributors/ContributorsSerializerTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/ContributorsSerializerTest.groovy
@@ -1,16 +1,17 @@
 package org.mockito.release.notes.contributors
 
+import org.mockito.release.notes.model.Contributor
 import spock.lang.Specification
 import spock.lang.Subject
 
 class ContributorsSerializerTest extends Specification {
 
-    @Subject serializer = new ContributorsSerializer(new File(System.getProperty("java.io.tmpdir") + "/contributors.json"))
-    def writer = new StringWriter()
+    File tempFile = new File(System.getProperty("java.io.tmpdir") + "/contributors.json")
+    @Subject serializer = new ContributorsSerializer(tempFile)
 
     def "serialization and deserialization of one contributor"() {
         given:
-        def contributors = new DefaultContributorsSet()
+        def contributors = new DefaultContributorsSet<Contributor>()
         def contributor = new DefaultContributor("myName", "myLogin", "myProfileUrl")
         contributors.addContributor(contributor)
 
@@ -25,7 +26,7 @@ class ContributorsSerializerTest extends Specification {
 
     def "serialization and deserialization of zero contributors"() {
         given:
-        def contributors = new DefaultContributorsSet()
+        def contributors = new DefaultContributorsSet<Contributor>()
 
         when:
         serializer.serialize(contributors)
@@ -34,11 +35,12 @@ class ContributorsSerializerTest extends Specification {
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
         contributors.getAllContributors().containsAll(actual.getAllContributors())
+        actual.size() == 0
     }
 
     def "serialization and deserialization of 2 contributors"() {
         given:
-        def contributors = new DefaultContributorsSet()
+        def contributors = new DefaultContributorsSet<Contributor>()
         def contributor1 = new DefaultContributor("myName 1", "myLogin 1", "myProfileUrl 1")
         def contributor2 = new DefaultContributor("myName 2", "myLogin 2", "myProfileUrl 2")
         contributors.addContributor(contributor1)
@@ -55,7 +57,7 @@ class ContributorsSerializerTest extends Specification {
 
     def "serialization and deserialization of 5 contributors"() {
         given:
-        def contributors = new DefaultContributorsSet()
+        def contributors = new DefaultContributorsSet<Contributor>()
         def contributor1 = new DefaultContributor("myName 1", "myLogin 1", "myProfileUrl 1")
         def contributor2 = new DefaultContributor("myName 2", "myLogin 2", "myProfileUrl 2")
         def contributor3 = new DefaultContributor("myName 3", "myLogin 3", "myProfileUrl 3")
@@ -78,7 +80,7 @@ class ContributorsSerializerTest extends Specification {
 
     def "serialization and deserialization contributors with special characters"() {
         given:
-        def contributors = new DefaultContributorsSet()
+        def contributors = new DefaultContributorsSet<Contributor>()
         def contributor = new DefaultContributor("my\"Na\\m\fe ", "my\rLo\bg\ni\tn", "\u0000myP\u001Fro\u007Ffi\u009FleUrl ")
         contributors.addContributor(contributor)
 

--- a/src/test/groovy/org/mockito/release/notes/contributors/ContributorsSerializerTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/ContributorsSerializerTest.groovy
@@ -17,7 +17,7 @@ class ContributorsSerializerTest extends Specification {
 
         when:
         serializer.serialize(contributors)
-        def actual = serializer.desrialize()
+        def actual = serializer.deserialize()
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -30,7 +30,7 @@ class ContributorsSerializerTest extends Specification {
 
         when:
         serializer.serialize(contributors)
-        def actual = serializer.desrialize()
+        def actual = serializer.deserialize()
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -48,30 +48,7 @@ class ContributorsSerializerTest extends Specification {
 
         when:
         serializer.serialize(contributors)
-        def actual = serializer.desrialize()
-
-        then:
-        actual.getAllContributors().containsAll(contributors.getAllContributors())
-        contributors.getAllContributors().containsAll(actual.getAllContributors())
-    }
-
-    def "serialization and deserialization of 5 contributors"() {
-        given:
-        def contributors = new DefaultContributorsSet<Contributor>()
-        def contributor1 = new DefaultContributor("myName 1", "myLogin 1", "myProfileUrl 1")
-        def contributor2 = new DefaultContributor("myName 2", "myLogin 2", "myProfileUrl 2")
-        def contributor3 = new DefaultContributor("myName 3", "myLogin 3", "myProfileUrl 3")
-        def contributor4 = new DefaultContributor("myName 4", "myLogin 4", "myProfileUrl 4")
-        def contributor5 = new DefaultContributor("myName 5", "myLogin 5", "myProfileUrl 5")
-        contributors.addContributor(contributor1)
-        contributors.addContributor(contributor2)
-        contributors.addContributor(contributor3)
-        contributors.addContributor(contributor4)
-        contributors.addContributor(contributor5)
-
-        when:
-        serializer.serialize(contributors)
-        def actual = serializer.desrialize()
+        def actual = serializer.deserialize()
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -86,7 +63,7 @@ class ContributorsSerializerTest extends Specification {
 
         when:
         serializer.serialize(contributors)
-        def actual = serializer.desrialize()
+        def actual = serializer.deserialize()
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())

--- a/src/test/groovy/org/mockito/release/notes/contributors/ContributorsToPomTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/ContributorsToPomTest.groovy
@@ -1,0 +1,98 @@
+package org.mockito.release.notes.contributors
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+
+class ContributorsToPomTest extends Specification {
+
+    @Subject sut = new ContributorsToPom()
+
+    def "should include all contributors from contributors set"() {
+        def node = new Node(null, "contributors")
+        def contributorsSet = [new DefaultProjectContributor("name 1", "login1", "profileUrl1", 1),
+                               new DefaultProjectContributor("name 2", "login2", "profileUrl2", 1)
+        ] as Set
+        def contributorsStringList = []
+        def developers = []
+
+        when:
+        sut.include(node, contributorsSet, contributorsStringList, developers)
+
+        then:
+        node.children().get(0).get("name").text() == "name 1"
+        node.children().get(0).get("url").text() == "profileUrl1"
+        node.children().get(1).get("name").text() == "name 2"
+        node.children().get(1).get("url").text() == "profileUrl2"
+    }
+
+    def "should include all contributors from contributors string list"() {
+        def node = new Node(null, "contributors")
+        def contributorsSet = [ ] as Set
+        def contributorsStringList = ["login1:name 1", "login2:name 2"]
+        def developers = []
+
+        when:
+        sut.include(node, contributorsSet, contributorsStringList, developers)
+
+        then:
+        node.children().get(0).get("name").text() == "name 1"
+        node.children().get(0).get("url").text() == "https://github.com/login1"
+        node.children().get(1).get("name").text() == "name 2"
+        node.children().get(1).get("url").text() == "https://github.com/login2"
+    }
+
+    def "should ignore contributor from set when it is a developer but check only login"() {
+        def node = new Node(null, "contributors")
+        def contributorsSet = [new DefaultProjectContributor("name 1", "login1", "profileUrl1", 1),
+                               new DefaultProjectContributor("name 2", "login2", "profileUrl2", 1)] as Set
+        def contributorsStringList = []
+        def developers = ["login1:different name"]
+
+        when:
+        sut.include(node, contributorsSet, contributorsStringList, developers)
+
+        then:
+        node.children().get(0).get("name").text() == "name 2"
+        node.children().get(0).get("url").text() == "profileUrl2"
+    }
+
+    def "should never ignore contributor from string even it is a developer"() {
+        def node = new Node(null, "contributors")
+        def contributorsSet = [new DefaultProjectContributor("name 1", "login1", "profileUrl1", 1),
+                               new DefaultProjectContributor("name 2", "login2", "profileUrl2", 1)] as Set
+        def contributorsStringList = ["login3:name 3"]
+        def developers = ["login3:name 3"]
+
+        when:
+        sut.include(node, contributorsSet, contributorsStringList, developers)
+
+        then:
+        node.children().get(0).get("name").text() == "name 3"
+        node.children().get(0).get("url").text() == "https://github.com/login3"
+        node.children().get(1).get("name").text() == "name 1"
+        node.children().get(1).get("url").text() == "profileUrl1"
+        node.children().get(2).get("name").text() == "name 2"
+        node.children().get(2).get("url").text() == "profileUrl2"
+    }
+
+    def "should always put contributors from string before from github"() {
+        def node = new Node(null, "contributors")
+        def contributorsSet = [new DefaultProjectContributor("name 1", "login1", "profileUrl1", 1),
+                               new DefaultProjectContributor("name 2", "login2", "profileUrl2", 1)] as Set
+        def contributorsStringList = ["login3:name 3"]
+        def developers = []
+
+        when:
+        sut.include(node, contributorsSet, contributorsStringList, developers)
+
+        then:
+        node.children().get(0).get("name").text() == "name 3"
+        node.children().get(0).get("url").text() == "https://github.com/login3"
+        node.children().get(1).get("name").text() == "name 1"
+        node.children().get(1).get("url").text() == "profileUrl1"
+        node.children().get(2).get("name").text() == "name 2"
+        node.children().get(2).get("url").text() == "profileUrl2"
+    }
+
+}

--- a/src/test/groovy/org/mockito/release/notes/contributors/GitHubAllContributorsJsonTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/GitHubAllContributorsJsonTest.groovy
@@ -1,0 +1,45 @@
+package org.mockito.release.notes.contributors
+
+import org.json.simple.JsonObject
+import spock.lang.Specification
+
+class GitHubAllContributorsJsonTest extends Specification {
+
+    def "parse regular contributors"() {
+        def contributorJson = new JsonObject(login: "szczepiq",
+                url: "https://api.github.com/users/szczepiq",
+                html_url: "https://github.com/szczepiq",
+                "contributions": 2427)
+        def userJson = new JsonObject(login: "szczepiq",
+                url: "https://api.github.com/users/szczepiq",
+                name: "Szczepan Faber")
+
+        when:
+        def contributor = GitHubAllContributorsJson.toContributor(contributorJson, userJson)
+
+        then:
+        contributor.name == "Szczepan Faber"
+        contributor.login == "szczepiq"
+        contributor.profileUrl == "https://github.com/szczepiq"
+        contributor.numberOfContributions == 2427
+    }
+
+    def "parse regular contributors with empty name"() {
+        def contributorJson = new JsonObject(login: "continuous-delivery-drone",
+                url: "https://api.github.com/users/continuous-delivery-drone",
+                html_url: "https://github.com/continuous-delivery-drone",
+                "contributions": 431)
+        def userJson = new JsonObject(login: "continuous-delivery-drone",
+                url: "https://api.github.com/users/continuous-delivery-drone",
+                name: null)
+
+        when:
+        def contributor = GitHubAllContributorsJson.toContributor(contributorJson, userJson)
+
+        then:
+        contributor.name == ""
+        contributor.login == "continuous-delivery-drone"
+        contributor.profileUrl == "https://github.com/continuous-delivery-drone"
+        contributor.numberOfContributions == 431
+    }
+}

--- a/src/test/groovy/org/mockito/release/notes/contributors/GitHubLastContributorsFetcherTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/GitHubLastContributorsFetcherTest.groovy
@@ -5,9 +5,9 @@ import org.mockito.release.notes.vcs.GitCommit
 import spock.lang.Specification
 import spock.lang.Subject
 
-class GitHubContributorsFetcherTest extends Specification {
+class GitHubLastContributorsFetcherTest extends Specification {
 
-    @Subject fetcher = new GitHubContributorsFetcher()
+    @Subject fetcher = new GitHubLastContributorsFetcher()
 
     def readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
 


### PR DESCRIPTION
TODO: 
- [x]  define dependencies between tasks better,
- [ ]  use releasing.team internal object for keeping data about contributors
- [x]  configuration option to disable adding contributors to pom.xml from github
- [x]  do not fetching data from GH if file with all project contributors exist (make it UP-TO-DATE)
- [ ]  remove old TODOs