### PR TITLE
Removed travisRelease task for simpler, more explicit release execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
  - true
 
 script:
-  - ./gradlew build -s
+  - ./gradlew build -s -i
 
 after_success:
   - ./gradlew travisRelease -s

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,8 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.6.7'
+version = '0.7.0'
+
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.7.0'
+version = '0.7.1'
 
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'

--- a/src/main/groovy/org/mockito/release/exec/DefaultProcessRunner.java
+++ b/src/main/groovy/org/mockito/release/exec/DefaultProcessRunner.java
@@ -56,6 +56,12 @@ public class DefaultProcessRunner implements ProcessRunner {
         try {
             Process process = new ProcessBuilder(commandLine).directory(workDir).redirectErrorStream(true).start();
             String output = mask(readFully(new BufferedReader(new InputStreamReader(process.getInputStream()))));
+
+            //TODO add sanity timeout when we move to Java 1.7
+            // 1. we can do something like process.waitFor(15, TimeUnit.MINUTES)
+            // 2. first, we need to change the compatibility, push to Gradle 3.0, stop building with Java 1.6.
+            process.waitFor();
+
             result = new ProcessResult(output, process);
         } catch (Exception e) {
             throw new ReleaseNotesException("Problems executing command:\n  " + maskedCommandLine, e);

--- a/src/main/groovy/org/mockito/release/exec/DefaultProcessRunner.java
+++ b/src/main/groovy/org/mockito/release/exec/DefaultProcessRunner.java
@@ -1,30 +1,73 @@
 package org.mockito.release.exec;
 
+import org.gradle.api.GradleException;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.mockito.release.notes.util.ReleaseNotesException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.util.Arrays;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
 
-class DefaultProcessRunner implements ProcessRunner {
+import static java.util.Arrays.asList;
+import static org.mockito.release.internal.gradle.util.StringUtil.join;
 
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultProcessRunner.class);
+//TODO since this class is already public, probably it's best if we keep things simple and remove it from the public API
+//1. Remove the ProcessRunner interface and Exec class
+//2. Move the runner to the internal package
+public class DefaultProcessRunner implements ProcessRunner {
+
+    private static final Logger LOG = Logging.getLogger(DefaultProcessRunner.class);
     private final File workDir;
+    private String secretValue;
 
-    DefaultProcessRunner(File workDir) {
+    public DefaultProcessRunner(File workDir) {
         this.workDir = workDir;
     }
 
     public String run(String... commandLine) {
-        LOG.info("Executing command: {}", (Object) commandLine);
+        return run(asList(commandLine));
+    }
 
+    public String run(List<String> commandLine) {
+        return run(LOG, commandLine);
+    }
+
+    String run(Logger log, List<String> commandLine) {
+        // WARNING!!! ensure that masked command line is used for all logging!!!
+        String maskedCommandLine = mask(join(commandLine, " "));
+        log.lifecycle("  Executing:\n    " + maskedCommandLine);
+
+        ProcessResult result = executeProcess(commandLine, maskedCommandLine);
+
+        if (result.getExitValue() != 0) {
+            throw new GradleException("Execution of command failed (exit code " + result.getExitValue() + "):\n" +
+                    "  " + maskedCommandLine + "\n" +
+                    "Captured command output:\n" + result.getOutput());
+        } else {
+            return result.getOutput();
+        }
+    }
+
+    private ProcessResult executeProcess(List<String> commandLine, String maskedCommandLine) {
+        ProcessResult result;
         try {
             Process process = new ProcessBuilder(commandLine).directory(workDir).redirectErrorStream(true).start();
-            return readFully(new BufferedReader(new InputStreamReader(process.getInputStream())));
+            String output = mask(readFully(new BufferedReader(new InputStreamReader(process.getInputStream()))));
+            result = new ProcessResult(output, process);
         } catch (Exception e) {
-            throw new ReleaseNotesException("Problems executing command: " + Arrays.toString(commandLine), e);
+            throw new ReleaseNotesException("Problems executing command:\n  " + maskedCommandLine, e);
         }
+        return result;
+    }
+
+    private String mask(String text) {
+        if (secretValue == null) {
+            return text;
+        }
+        return text.replace(secretValue, "[SECRET]");
     }
 
     private static String readFully(BufferedReader reader) throws IOException {
@@ -37,6 +80,33 @@ class DefaultProcessRunner implements ProcessRunner {
             return sb.toString();
         } finally {
             reader.close();
+        }
+    }
+
+    /**
+     * @param secretValue to be masked from the output and logging
+     * @return this runner
+     */
+    public DefaultProcessRunner setSecretValue(String secretValue) {
+        this.secretValue = secretValue;
+        return this;
+    }
+
+    private static class ProcessResult {
+        private final String output;
+        private final Process process;
+
+        public ProcessResult(String output, Process process) {
+            this.output = output;
+            this.process = process;
+        }
+
+        public String getOutput() {
+            return output;
+        }
+
+        public int getExitValue() {
+            return process.exitValue();
         }
     }
 }

--- a/src/main/groovy/org/mockito/release/exec/ProcessRunner.java
+++ b/src/main/groovy/org/mockito/release/exec/ProcessRunner.java
@@ -1,5 +1,7 @@
 package org.mockito.release.exec;
 
+import java.util.List;
+
 /**
  * Provides ways to execute external processes
  */
@@ -12,4 +14,12 @@ public interface ProcessRunner {
      * @return combined error and standard output.
      */
     String run(String ... commandLine);
+
+    /**
+     * Executes given command line and returns result.
+     *
+     * @param commandLine the full command line to execute
+     * @return combined error and standard output.
+     */
+    String run(List<String> commandLine);
 }

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -26,7 +26,8 @@ public class ReleaseConfiguration {
 
     public ReleaseConfiguration() {
         //Configure default values
-        this.git.setTagPrefix("v");
+        this.git.setTagPrefix("v"); //so that tags are "v1.0", "v2.3.4"
+        this.git.setReleasableBranchRegex("master|release/.+");  // matches 'master', 'release/2.x', 'release/3.x', etc.
     }
 
     private boolean dryRun;

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -208,7 +208,7 @@ public class ReleaseConfiguration {
         }
 
         /**
-         * Regex to be used to identify branches that entitled to be released, for example "master|release/.+"
+         * Regex to be used to identify branches that are entitled to be released, for example "master|release/.+"
          */
         public String getReleasableBranchRegex() {
             return getString("git.releasableBranchRegex");

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -113,11 +113,11 @@ public class ReleaseConfiguration {
          */
         public String getWriteAuthToken() {
             return (String) getValue("gitHub.writeAuthToken", "GH_WRITE_TOKEN",
-                    "Please configure 'releasing." + "gitHub.writeAuthToken" + "' value.\n" +
-                    "  It is highly recommended to use env variable for sensitive information\n" +
-                    "  and store secured value with your CI configuration.\n" +
-                    "  Example 'build.gradle' file:\n" +
-                    "    releasing." + "gitHub.writeAuthToken" + " = System.getenv('GH_WRITE_TOKEN')");
+                    "Please export 'GH_WRITE_TOKEN' env variable first!\n" +
+                    "  The value of that variable is automatically used for 'releasing.gitHub.writeAuthToken' setting.\n" +
+                    "  It is highly recommended to keep write token secure and store env variable with your CI configuration.\n" +
+                    "  Alternatively, you can configure the write token explicitly in the *.gradle file:\n" +
+                    "    releasing.gitHub.writeAuthToken = 'secret'");
         }
 
         public void setWriteAuthToken(String writeAuthToken) {

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -71,6 +71,9 @@ public class ReleaseNeededTask extends DefaultTask {
 
         boolean notNeeded = skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch;
 
+        //TODO add more color to the message
+        //add env variable names, what is the current branch, what is the regexp, etc.
+        //This way it is easier to understand how stuff works by reading the log
         String message = "  Release is needed: " + !notNeeded +
                 "\n    - skip by env variable: " + skipEnvVariable +
                 "\n    - skip by commit message: " + skippedByCommitMessage +

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -1,0 +1,86 @@
+package org.mockito.release.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * Decides if the release is needed.
+ * The release is <strong>not needed</strong> when any of below is true:
+ *  - the env variable 'SKIP_RELEASE' is present
+ *  - the commit message, loaded from 'TRAVIS_COMMIT_MESSAGE' env variable contains '[ci skip-release]' keyword
+ *  - the env variable 'TRAVIS_PULL_REQUEST' is not empty, not an empty String and and not 'false'
+ *  - the branch ({@link #getBranch()} does not match release-eligibility regex ({@link #getReleasableBranchRegex()}.
+ */
+public class ReleaseNeededTask extends DefaultTask {
+
+    private final static Logger LOG = Logging.getLogger(ReleaseNeededTask.class);
+
+    //TODO we should consider exposing the configuration below in the ReleaseConfiguration
+    //For example, 'releasing.git.commit.message', 'releasing.git.commit.skipReleaseKeyword', 'releasing.skip', 'releasing.git.pullRequest'
+    //Goal: have all configuration in the extension object, have all env variable handling there for centralized documentation
+
+    private final static String SKIP_RELEASE_ENV = "SKIP_RELEASE";
+    private final static String COMMIT_MESSAGE_ENV = "TRAVIS_COMMIT_MESSAGE";
+    private final static String PULL_REQUEST_ENV = "TRAVIS_PULL_REQUEST";
+    private final static String SKIP_RELEASE_KEYWORD = "[ci skip-release]";
+
+    private String branch;
+    private String releasableBranchRegex;
+
+    /**
+     * The branch we currently operate on
+     */
+    public String getBranch() {
+        return branch;
+    }
+
+    /**
+     * See {@link #getBranch()}
+     */
+    public void setBranch(String branch) {
+        this.branch = branch;
+    }
+
+    /**
+     * Regex to be used to identify branches that are entitled to be released, for example "master|release/.+"
+     */
+    public String getReleasableBranchRegex() {
+        return releasableBranchRegex;
+    }
+
+    /**
+     * See {@link #getReleasableBranchRegex()}
+     */
+    public void setReleasableBranchRegex(String releasableBranchRegex) {
+        this.releasableBranchRegex = releasableBranchRegex;
+    }
+
+    @TaskAction public void releaseNeeded() {
+        boolean skipEnvVariable = System.getenv(SKIP_RELEASE_ENV) != null;
+        String commitMessage = System.getenv(COMMIT_MESSAGE_ENV);
+        boolean skippedByCommitMessage = commitMessage != null && commitMessage.contains(SKIP_RELEASE_KEYWORD);
+
+        //returns true only if pull request env variable points to PR number
+        String pr = System.getenv(PULL_REQUEST_ENV);
+        boolean pullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
+
+        boolean releasableBranch = branch != null && branch.matches(releasableBranchRegex);
+
+        boolean notNeeded = skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch;
+
+        String message = "  Release is needed: " + !notNeeded +
+                "\n    - skip by env variable: " + skipEnvVariable +
+                "\n    - skip by commit message: " + skippedByCommitMessage +
+                "\n    - is pull request build:  " + pullRequest +
+                "\n    - is releasable branch:  " + releasableBranch;
+
+        if (notNeeded) {
+            throw new GradleException(message);
+        } else {
+            LOG.lifecycle(message);
+        }
+    }
+}

--- a/src/main/groovy/org/mockito/release/gradle/SecureExecTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/SecureExecTask.java
@@ -1,0 +1,55 @@
+package org.mockito.release.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import org.mockito.release.exec.DefaultProcessRunner;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Similar to Gradle's built-in {@link org.gradle.api.tasks.Exec}
+ * but it does not expose the command line parameters when build is executed with '-i' (--info) level.
+ * It masks secret value configured via {@link #setSecretValue(String)} from logging, task output and exception messages.
+ * Replaces secret value with "[SECRET]".
+ * It really helps debugging if we can see the output and logging without exposing secret values like GitHub auth token.
+ */
+public class SecureExecTask extends DefaultTask {
+
+    private List<String> commandLine = new LinkedList<String>();
+    private String secretValue;
+
+    /**
+     * @return command line to be executed
+     */
+    public List<String> getCommandLine() {
+        return commandLine;
+    }
+
+    /**
+     * @param commandLine command line to be executed
+     */
+    public void setCommandLine(List<String> commandLine) {
+        this.commandLine = commandLine;
+    }
+
+    /**
+     * @return value to be secured, e.g. masked from forked process output and logging
+     */
+    public String getSecretValue() {
+        return secretValue;
+    }
+
+    /**
+     * See {@link #getSecretValue()}
+     */
+    public void setSecretValue(String secretValue) {
+        this.secretValue = secretValue;
+    }
+
+    @TaskAction public void secureExec() {
+        new DefaultProcessRunner(getProject().getProjectDir())
+            .setSecretValue(secretValue)
+            .run(commandLine);
+    }
+}

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -148,8 +148,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                         String pr = System.getenv("TRAVIS_PULL_REQUEST");
                         boolean pullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
 
-                        //TODO create task that reads the current branch in case TRAVIS_BRANCH env variable is not set
-                        String branch = System.getenv("TRAVIS_BRANCH");
+                        String branch = conf.getGit().getBranch();
                         boolean releasableBranch = branch != null && branch.matches(conf.getGit().getReleasableBranchRegex());
 
                         boolean notNeeded = skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch;
@@ -191,7 +190,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                 });
 
                 //TODO I think we should consider deleting 'travisRelease' task. It could be repaced by something like:
-                //./gradlew assertReleaseNeeded && ./gradlew travisReleasePrepare && ./gradlew performRelease releaseCleanUp -PreleaseDryRun && ./gradlew performRelease
+                //./gradlew assertReleaseNeeded && ./gradlew travisReleasePrepare && ./gradlew performRelease releaseCleanUp && ./gradlew performRelease -PreleaseDryRun=false
                 //assertReleaseNeeded task would fail when release is not needed and would stop executing further commands.
             }
         });

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -6,12 +6,12 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Exec;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
 import org.mockito.release.gradle.BumpVersionFileTask;
 import org.mockito.release.gradle.ReleaseConfiguration;
+import org.mockito.release.gradle.ReleaseNeededTask;
 import org.mockito.release.internal.gradle.util.StringUtil;
 import org.mockito.release.internal.gradle.util.TaskMaker;
 import org.mockito.release.version.VersionInfo;
@@ -134,64 +134,11 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
             }
         });
 
-        final Task releaseNeededTask = TaskMaker.task(project, "releaseNeeded", new Action<Task>() {
-            public void execute(final Task t) {
-                t.setDescription("Checks if the criteria for the release are met.");
-                t.doLast(new Action<Task>() {
-                    public void execute(Task task) {
-                        //TODO hardcoded literals
-                        boolean skipEnvVariable = System.getenv("SKIP_RELEASE") != null;
-                        String commitMessage = System.getenv("TRAVIS_COMMIT_MESSAGE");
-                        boolean skippedByCommitMessage = commitMessage != null && commitMessage.contains("[ci skip-release]");
-
-                        //returns true only if pull request env variable points to PR number
-                        String pr = System.getenv("TRAVIS_PULL_REQUEST");
-                        boolean pullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
-
-                        String branch = conf.getGit().getBranch();
-                        boolean releasableBranch = branch != null && branch.matches(conf.getGit().getReleasableBranchRegex());
-
-                        boolean notNeeded = skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch;
-                        //TODO task type, otherwise 'needed' is just a String, no type safety
-                        t.getExtensions().getExtraProperties().set("needed", !notNeeded);
-
-                        LOG.lifecycle("  Release is needed: " + !notNeeded +
-                                "\n    - skip by env variable: " + skipEnvVariable +
-                                "\n    - skip by commit message: " + skippedByCommitMessage +
-                                "\n    - is pull request build:  " + pullRequest +
-                                "\n    - is releasable branch:  " + releasableBranch);
-                    }
-                });
-            }
-        });
-
-        TaskMaker.task(project, "travisRelease", new Action<Task>() {
-            public void execute(final Task t) {
-                t.setDescription("Performs the release if release criteria are met, intended to be used by Travis CI job");
-                t.dependsOn("releaseNeeded");
-                t.onlyIf(new Spec<Task>() {
-                    public boolean isSatisfiedBy(Task task) {
-                        //also checking didWork so that we can "-x releaseNeeded" to force the release without criteria check
-                        return releaseNeededTask.getDidWork()
-                                //TODO below is awkward, we need a new task type
-                                && (Boolean) releaseNeededTask.getExtensions().getExtraProperties().get("needed");
-                    }
-                });
-                t.doLast(new Action<Task>() {
-                    public void execute(Task task) {
-                        LOG.lifecycle("  Performing release of version '{}' (notable version: {})", project.getVersion(), notableRelease);
-                        //first, we need to prepare Travis working copy
-                        exec(project, "./gradlew", "travisReleasePrepare");
-                        //then, we will do the full release with dry run to flesh out any issues
-                        performReleaseTest(project);
-                        //finally, let's make the release!
-                        exec(project, "./gradlew", "performRelease");
-                    }
-                });
-
-                //TODO I think we should consider deleting 'travisRelease' task. It could be repaced by something like:
-                //./gradlew assertReleaseNeeded && ./gradlew travisReleasePrepare && ./gradlew performRelease releaseCleanUp && ./gradlew performRelease -PreleaseDryRun=false
-                //assertReleaseNeeded task would fail when release is not needed and would stop executing further commands.
+        TaskMaker.task(project, "assertReleaseNeeded", ReleaseNeededTask.class, new Action<ReleaseNeededTask>() {
+            public void execute(ReleaseNeededTask t) {
+                t.setDescription("Asserts that criteria for the release are met and throws exception if release not needed.");
+                t.setBranch(conf.getGit().getBranch());
+                t.setReleasableBranchRegex(conf.getGit().getReleasableBranchRegex());
             }
         });
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -12,6 +12,7 @@ import org.gradle.process.ExecSpec;
 import org.mockito.release.gradle.BumpVersionFileTask;
 import org.mockito.release.gradle.ReleaseConfiguration;
 import org.mockito.release.gradle.ReleaseNeededTask;
+import org.mockito.release.internal.gradle.configuration.LazyConfiguration;
 import org.mockito.release.internal.gradle.util.StringUtil;
 import org.mockito.release.internal.gradle.util.TaskMaker;
 import org.mockito.release.version.VersionInfo;
@@ -135,10 +136,15 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
         });
 
         TaskMaker.task(project, "assertReleaseNeeded", ReleaseNeededTask.class, new Action<ReleaseNeededTask>() {
-            public void execute(ReleaseNeededTask t) {
+            public void execute(final ReleaseNeededTask t) {
                 t.setDescription("Asserts that criteria for the release are met and throws exception if release not needed.");
-                t.setBranch(conf.getGit().getBranch());
                 t.setReleasableBranchRegex(conf.getGit().getReleasableBranchRegex());
+
+                LazyConfiguration.lazyConfiguration(t, new Runnable() {
+                    public void run() {
+                        t.setBranch(conf.getGit().getBranch());
+                    }
+                });
             }
         });
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/GitPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/GitPlugin.java
@@ -8,10 +8,9 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Exec;
 import org.mockito.release.gradle.ReleaseConfiguration;
+import org.mockito.release.gradle.SecureExecTask;
 import org.mockito.release.internal.gradle.util.GitUtil;
 import org.mockito.release.internal.gradle.util.TaskMaker;
-
-import java.io.ByteArrayOutputStream;
 
 import static org.mockito.release.internal.gradle.configuration.LazyConfiguration.lazyConfiguration;
 import static org.mockito.release.internal.gradle.util.GitUtil.getTag;
@@ -59,22 +58,15 @@ public class GitPlugin implements Plugin<Project> {
             }
         });
 
-        boolean mustBeQuiet = true; //so that we don't expose the token
-        TaskMaker.execTask(project, PUSH_TASK, mustBeQuiet, new Action<Exec>() {
-            public void execute(final Exec t) {
+        TaskMaker.task(project, PUSH_TASK, SecureExecTask.class, new Action<SecureExecTask>() {
+            public void execute(final SecureExecTask t) {
                 t.setDescription("Pushes changes to remote repo.");
                 t.mustRunAfter(COMMIT_TASK, TAG_TASK);
 
-                //!!!We must capture and hide the output because when git push fails it can expose the token!
-                ByteArrayOutputStream output = new ByteArrayOutputStream();
-                t.setStandardOutput(output);
-                t.setErrorOutput(output);
-                //TODO instead of being quiet and not printing the output at all, we should instead print the output
-                //and replace the sensitive value with [SECRET]. This way, the task is neatly debuggable.
-
                 lazyConfiguration(t, new Runnable() {
                     public void run() {
-                        t.commandLine(GitUtil.getQuietGitPushArgs(conf, project));
+                        t.setCommandLine(GitUtil.getGitPushArgs(conf, project));
+                        t.setSecretValue(conf.getGitHub().getWriteAuthToken());
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/GitPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/GitPlugin.java
@@ -69,6 +69,8 @@ public class GitPlugin implements Plugin<Project> {
                 ByteArrayOutputStream output = new ByteArrayOutputStream();
                 t.setStandardOutput(output);
                 t.setErrorOutput(output);
+                //TODO instead of being quiet and not printing the output at all, we should instead print the output
+                //and replace the sensitive value with [SECRET]. This way, the task is neatly debuggable.
 
                 lazyConfiguration(t, new Runnable() {
                     public void run() {

--- a/src/main/groovy/org/mockito/release/internal/gradle/configuration/LazyConfiguration.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/configuration/LazyConfiguration.java
@@ -28,6 +28,7 @@ public class LazyConfiguration {
             for (Task key : actions.keySet()) {
                 if (graph.hasTask(key)) {
                     for (Runnable r : actions.get(key)) {
+                        //TODO add 'info' level logging explaining what happens. Similar to how we do it in DeferredConfiguration
                         r.run();
                     }
                 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/GitUtil.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/GitUtil.java
@@ -1,13 +1,11 @@
 package org.mockito.release.internal.gradle.util;
 
 import org.gradle.api.Project;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.mockito.release.gradle.ReleaseConfiguration;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 
@@ -17,30 +15,20 @@ import static java.util.Arrays.asList;
 public class GitUtil {
     //TODO unit testable
 
-    private final static Logger LOG = Logging.getLogger(GitUtil.class);
-
     /**
      * Quiet command line to be used to perform git push without exposing write token
      */
-    public static Collection<String> getQuietGitPushArgs(ReleaseConfiguration conf, Project project) {
-        //TODO push everyting on conf object, get rid of ext
-        //!!!Below command _MUST_ be quiet otherwise it exposes GitHub write token!!!
-        String mustBeQuiet = "-q";
+    public static List<String> getGitPushArgs(ReleaseConfiguration conf, Project project) {
         String ghUser = conf.getGitHub().getWriteAuthUser();
         String ghWriteToken = conf.getGitHub().getWriteAuthToken();
         String ghRepo = conf.getGitHub().getRepository();
         String branch = conf.getGit().getBranch();
-        String url = MessageFormat.format("https://{0}:[SECRET]@github.com/{1}.git", ghUser, ghRepo);
+        String url = MessageFormat.format("https://{0}:{1}@github.com/{2}.git", ghUser, ghWriteToken, ghRepo);
 
-        ArrayList<String> args = new ArrayList<String>(asList("git", "push", url, branch, getTag(conf, project), mustBeQuiet));
+        ArrayList<String> args = new ArrayList<String>(asList("git", "push", url, branch, getTag(conf, project)));
         if (conf.isDryRun()) {
             args.add("--dry-run");
         }
-        //TODO git push arguments should be printed when task runs and not when the args are configured on the task
-        LOG.lifecycle("  'git push' arguments:\n    {}", StringUtil.join(args, " "));
-        //!!! Setting the url after printing the command so that we don't expose the sensitive token!!!
-        String actualUrl = args.get(2).replace("[GH_WRITE_TOKEN]", ghWriteToken);
-        args.set(2, actualUrl);
         return args;
     }
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/TaskMaker.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/TaskMaker.java
@@ -26,20 +26,10 @@ public class TaskMaker {
      * Creates exec task with preconfigured defaults
      */
     public static Exec execTask(Project project, String name, Action<Exec> configure) {
-        return execTask(project, name, false, configure);
-    }
-
-    /**
-     * Creates exec task with preconfigured defaults
-     */
-    public static Exec execTask(Project project, String name, final boolean quiet, Action<Exec> configure) {
-        //TODO unit testable
         final Exec exec = project.getTasks().create(name, Exec.class);
         exec.doFirst(new Action<Task>() {
             public void execute(Task task) {
-                if (!quiet) {
-                    LOG.lifecycle("  Running:\n    {}", join(exec.getCommandLine(), " "));
-                }
+                LOG.lifecycle("  Running:\n    {}", join(exec.getCommandLine(), " "));
             }
         });
         return configure(configure, exec);


### PR DESCRIPTION
Usually better to review commit-by-commit.

1. Removed travisRelease task
2. Enabled preconfiguring release with some standard env variables
3. Refactorings / TODOs
4. Fixed issues around git push task and masking of its arguments

Regarding 1) travisRelease task:

a) This task was hard to maintain / work with.
Forking off Gradle builds from inside Gradle build is problematic
because it is hard to fine tune the child Gradle build.
For example, there is no easy way to run the child Gradle build
with some extra flags like '-s' or '-i'. Also running Gradle from Gradle makes the console output really confusing.

b) I removed the task completely. Instead of this CI configuration:

```
./gradlew travisRelease
```

The CI build is configured this way:

```
./gradlew assertReleaseNeeded && ./gradlew travisReleasePrepare && ./gradlew performRelease
```

This is more code, but it is way more flexible to work with,
makes it easy to reproduce builds by running individual tasks.
Also, it is very explicit, removes the "magic" from the process.

c) New "assertReleaseNeeded" task fails when release is not needed.
This way, we can stop executing further steps.
This is useful when configuring CI builds.