### PR TITLE
Removed testRelease task, set dryRun by default, logging glitch fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.7.1'
+version = '0.7.2'
 
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'

--- a/src/main/groovy/org/mockito/release/gradle/BumpVersionFileTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/BumpVersionFileTask.java
@@ -59,11 +59,13 @@ public class BumpVersionFileTask extends DefaultTask {
     @TaskAction public void bumpVersionFile() {
         VersionInfo versionInfo = Version.versionInfo(this.versionFile);
         VersionInfo newVersion = versionInfo.bumpVersion(updateNotableVersions);
+        //TODO add unit test for the message.
+        // We already had a bug related to printing VersionInfo toString() instead of neat string version.
         LOG.lifecycle("{} - updated version file '{}'\n" +
                 "  - new version: {}\n" +
                 "  - notable versions updated: {}\n" +
                 "  - notable versions: {}",
-                getPath(), getProject().relativePath(this.versionFile), newVersion, updateNotableVersions,
+                getPath(), getProject().relativePath(this.versionFile), newVersion.getVersion(), updateNotableVersions,
                 StringUtil.join(versionInfo.getNotableVersions(), ", "));
     }
 }

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -30,7 +30,7 @@ public class ReleaseConfiguration {
         this.git.setReleasableBranchRegex("master|release/.+");  // matches 'master', 'release/2.x', 'release/3.x', etc.
     }
 
-    private boolean dryRun;
+    private boolean dryRun = true;
 
     public void setDryRun(boolean dryRun) {
         this.dryRun = dryRun;

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPlugin.java
@@ -23,11 +23,11 @@ public class ReleaseConfigurationPlugin implements Plugin<Project> {
             configuration = project.getRootProject().getExtensions()
                     .create("releasing", ReleaseConfiguration.class);
 
-            if (project.hasProperty("releaseDryRun")) {
-                //TODO rename to releasing.dryRun for consistency
+            if (project.hasProperty("releasing.dryRun")) {
+                Object value = project.getProperties().get("releasing.dryRun");
+                configuration.setDryRun(!"false".equals(value));
                 //TODO we can actually implement it so that we automatically preconfigure everything by command line parameters
                 //e.g. releasing.gitHub.repository is also a property
-                configuration.setDryRun(true);
             }
         } else {
             //not root project, get extension from root project

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPluginTest.groovy
@@ -2,6 +2,7 @@ package org.mockito.release.internal.gradle
 
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ReleaseConfigurationPluginTest extends Specification {
 
@@ -18,14 +19,24 @@ class ReleaseConfigurationPluginTest extends Specification {
         subproject.plugins.apply(ReleaseConfigurationPlugin).configuration == root.plugins.apply(ReleaseConfigurationPlugin).configuration
     }
 
-    def "dry run off by default"() {
-        expect:
-        !root.plugins.apply(ReleaseConfigurationPlugin).configuration.dryRun
-    }
-
-    def "configures dry run by project property"() {
-        root.ext.releaseDryRun = ""
+    def "dry run on by default"() {
         expect:
         root.plugins.apply(ReleaseConfigurationPlugin).configuration.dryRun
+    }
+
+    @Unroll
+    def "configures dry run to #setting when project property is #property"() {
+        when:
+        root.ext.'releasing.dryRun' = property
+
+        then:
+        root.plugins.apply(ReleaseConfigurationPlugin).configuration.dryRun == setting
+
+        where:
+        property | setting
+        "false"  | false
+        "true"   | true
+        ""       | true
+        null     | true
     }
 }


### PR DESCRIPTION
Review by commit is easier ;)

1. Removed 'testRelease' task, enabled release dry by default
2. Fixed glitch with logging version when the build starts

#### Regarding 1)

a) testRelease task was problematic because it was forking Gradle build from Gradle build.
This approach turned out to be impractical because the logging from builds gets mixed up.
Also, there is no way to control the child build and pass any parameters like '-i' logging level.
b) testing release now is just running './gradlew performRelease' or './gradlew performRelease releaseCleanUp'
c) changed the default of release to be dryRun=true.
This way it is safer (no accidental releases).
Also, it is easier to test without forgetting to pass project property.

#### Regarding 2)

The version that was printed was actually a string representation of VersionInfo object.
Instead, want to print version like "2.9.0"