### PR TITLE
version.properties file created automatically if doesnt exist #70

### DIFF
--- a/src/main/groovy/org/mockito/release/internal/gradle/VersioningPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/VersioningPlugin.java
@@ -39,7 +39,9 @@ public class VersioningPlugin implements Plugin<Project> {
 
     private static Logger LOG = Logging.getLogger(VersioningPlugin.class);
 
-    public final static String VERSION_FILE_NAME = "version.properties";
+    public static final String VERSION_FILE_NAME = "version.properties";
+    public static final String GRADLE_DEFAULT_VERSION = "unspecified";
+    public static final String FALLBACK_INITIAL_VERSION = "0.0.1";
 
     public void apply(Project project) {
         final File versionFile = project.file(VERSION_FILE_NAME);
@@ -71,11 +73,24 @@ public class VersioningPlugin implements Plugin<Project> {
 
     private void createVersionPropertiesFile(Project project, File versionFile) {
         LOG.lifecycle("  Required file version.properties doesn't exist. Creating it automatically. Remember about checking it into VCS!");
-        LOG.lifecycle("  Initial project version in version.properties set to {}", project.getVersion());
+        LOG.lifecycle("  You shouldn't configure project.version in build.gradle anymore. Version from version.properties will be used instead.");
+
+        String version = determineVersion(project);
+
         String versionFileContent = "#Version of the produced binaries. This file is intended to be checked-in.\n"
                 + "#It will be automatically bumped by release automation.\n"
-                + "version=" + project.getVersion() + "\n";
+                + "version=" + version + "\n";
 
         IOUtil.writeFile(versionFile, versionFileContent);
+    }
+
+    private String determineVersion(Project project){
+        if(GRADLE_DEFAULT_VERSION.equals(project.getVersion()) ){
+            LOG.lifecycle("  BEWARE! Project.version is unspecified. Version will be set to {}. You can change it manually in version.properties.", FALLBACK_INITIAL_VERSION);
+            return FALLBACK_INITIAL_VERSION;
+        } else{
+            LOG.lifecycle("  Initial project version in version.properties set to {} (taken from project.version property).", project.getVersion());
+            return project.getVersion().toString();
+        }
     }
 }

--- a/src/test/groovy/org/mockito/release/internal/gradle/VersioningPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/VersioningPluginTest.groovy
@@ -1,0 +1,61 @@
+package org.mockito.release.internal.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import org.mockito.release.version.VersionInfo
+import spock.lang.Specification
+
+class VersioningPluginTest extends Specification {
+
+    @Rule TemporaryFolder tmp = new TemporaryFolder()
+    def project
+    def initialVersionFileContent = "version=1.0.0\nnotableVersions=0.1.0\n"
+
+    def setup(){
+        project = new ProjectBuilder().withProjectDir(tmp.root).build()
+    }
+
+    def "should generate version properties if it doesn't exist"() {
+        given:
+        assert !project.file(VersioningPlugin.VERSION_FILE_NAME).exists()
+        project.version("0.5.0")
+
+        when:
+        project.plugins.apply(VersioningPlugin)
+
+        then:
+        project.file(VersioningPlugin.VERSION_FILE_NAME).text ==
+                "#Version of the produced binaries. This file is intended to be checked-in.\n" +
+                "#It will be automatically bumped by release automation.\n" +
+                "version=0.5.0\n"
+    }
+
+    def "should not modify version properties if it already exists"() {
+        given:
+        project.file(VersioningPlugin.VERSION_FILE_NAME) << initialVersionFileContent
+
+        when:
+        project.plugins.apply(VersioningPlugin)
+
+        then:
+        project.file(VersioningPlugin.VERSION_FILE_NAME).text == initialVersionFileContent
+    }
+
+
+    def "should set extensions properly"() {
+        given:
+        project.file(VersioningPlugin.VERSION_FILE_NAME) << initialVersionFileContent
+
+        when:
+        project.plugins.apply(VersioningPlugin)
+
+        then:
+        def versionInfo = project.extensions.getByType(VersionInfo)
+        versionInfo.versionFile == project.file(VersioningPlugin.VERSION_FILE_NAME)
+        versionInfo.version == "1.0.0"
+        versionInfo.notableVersions == ["0.1.0"] as LinkedList
+
+        project.extensions.extraProperties.get("release_notable") == true
+    }
+}


### PR DESCRIPTION
Version.properties is created automatically and set to project.version. 

I also added a unit test for checking if extensions are correctly set (that's why I removed TODO line).

@szczepiq @mstachniuk 
What do you think about the case when user doesn't have project.version set at the moment when VersioningPlugin is being configured? Project.version returns "unspecified" then and we have a failure a little later (in VersionBumper#incrementVersion) because "unspecified" doesn't comply with our regex pattern for version.

Would setting the version to '0.1.0' be too much of intrusion into the project? 