### PR TITLE
Specify publication repository in the release notes

### DIFF
--- a/src/main/groovy/org/mockito/release/gradle/IncrementalReleaseNotes.java
+++ b/src/main/groovy/org/mockito/release/gradle/IncrementalReleaseNotes.java
@@ -98,6 +98,7 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
      * The target repository where the publications / binaries are published to.
      * Shown in the release notes.
      */
+    @Input
     public String getPublicationRepository() {
         return publicationRepository;
     }

--- a/src/main/groovy/org/mockito/release/gradle/IncrementalReleaseNotes.java
+++ b/src/main/groovy/org/mockito/release/gradle/IncrementalReleaseNotes.java
@@ -25,6 +25,7 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
     private String gitHubReadOnlyAuthToken;
     private String gitHubRepository;
     private Map<String, String> gitHubLabelMapping = new LinkedHashMap<String, String>();
+    private String publicationRepository;
 
     /**
      * Release notes file this task operates on.
@@ -91,6 +92,21 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
      */
     public void setGitHubLabelMapping(Map<String, String> gitHubLabelMapping) {
         this.gitHubLabelMapping = gitHubLabelMapping;
+    }
+
+    /**
+     * The target repository where the publications / binaries are published to.
+     * Shown in the release notes.
+     */
+    public String getPublicationRepository() {
+        return publicationRepository;
+    }
+
+    /**
+     * See {@link #getPublicationRepository()}
+     */
+    public void setPublicationRepository(String publicationRepository) {
+        this.publicationRepository = publicationRepository;
     }
 
     private void assertConfigured() {

--- a/src/main/groovy/org/mockito/release/gradle/IncrementalReleaseNotes.java
+++ b/src/main/groovy/org/mockito/release/gradle/IncrementalReleaseNotes.java
@@ -151,7 +151,7 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
         String current = "HEAD";
         LOG.lifecycle("  Generating release note for revisions: {} -> {}", prev, current);
         String v = this.getProject().getVersion().toString();
-        String newContent = builder.buildNotes(v, prev, current, gitHubLabelMapping);
+        String newContent = builder.buildNotes(v, prev, current, gitHubLabelMapping, publicationRepository);
         return newContent;
     }
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -156,14 +156,14 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
         });
     }
 
-    private void configurePublicationRepo(Project project, String bintrayRepo) {
+    private static void configurePublicationRepo(Project project, String bintrayRepo) {
         //not using 'getTasks().withType()' because I don't want to create too many task configuration rules
         //TODO add information about it in the development guide
         for (Task t : project.getTasks()) {
             if (t instanceof IncrementalReleaseNotes) {
-                LOG.info("Configuring publication repository: {} on task: {}", bintrayRepo, t.getPath());
                 IncrementalReleaseNotes task = (IncrementalReleaseNotes) t;
-                if (task.getPublicationRepository() != null) {
+                if (task.getPublicationRepository() == null) {
+                    LOG.info("Configuring publication repository '{}' on task: {}", bintrayRepo, t.getPath());
                     task.setPublicationRepository(bintrayRepo);
                 }
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -61,8 +61,6 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
             }
         });
 
-        configureNotableReleaseNotes(project, notableRelease);
-
         TaskMaker.execTask(project, "gitAddReleaseNotes", new Action<Exec>() {
             public void execute(final Exec t) {
                 t.setDescription("Performs 'git add' for the release notes file");
@@ -144,19 +142,5 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                 });
             }
         });
-    }
-
-    private static void configureNotableReleaseNotes(Project project, boolean notableRelease) {
-        VersionInfo versionInfo = project.getExtensions().getByType(VersionInfo.class);
-        NotableReleaseNotesGeneratorTask generatorTask = (NotableReleaseNotesGeneratorTask) project.getTasks().getByName("updateNotableReleaseNotes");
-        NotableReleaseNotesFetcherTask fetcherTask = (NotableReleaseNotesFetcherTask) project.getTasks().getByName("fetchNotableReleaseNotes");
-
-        generatorTask.getNotesGeneration().setTargetVersions(versionInfo.getNotableVersions());
-        fetcherTask.getNotesGeneration().setTargetVersions(versionInfo.getNotableVersions());
-
-        if (notableRelease) {
-            generatorTask.getNotesGeneration().setHeadVersion(project.getVersion().toString());
-            fetcherTask.getNotesGeneration().setHeadVersion(project.getVersion().toString());
-        }
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -1,5 +1,6 @@
 package org.mockito.release.internal.gradle;
 
+import com.jfrog.bintray.gradle.BintrayExtension;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -8,11 +9,14 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Exec;
 import org.mockito.release.gradle.BumpVersionFileTask;
+import org.mockito.release.gradle.IncrementalReleaseNotes;
 import org.mockito.release.gradle.ReleaseConfiguration;
 import org.mockito.release.gradle.ReleaseNeededTask;
 import org.mockito.release.internal.gradle.configuration.LazyConfiguration;
 import org.mockito.release.internal.gradle.util.TaskMaker;
 import org.mockito.release.version.VersionInfo;
+
+import static org.mockito.release.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
 
 /**
  * Opinionated continuous delivery plugin.
@@ -87,11 +91,19 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
         //TODO can we make git push and bintray upload tasks to be last (expensive, hard to reverse tasks should go last)
 
         project.allprojects(new Action<Project>() {
-            public void execute(final Project project) {
-                project.getPlugins().withType(BintrayPlugin.class, new Action<BintrayPlugin>() {
+            public void execute(final Project p) {
+                p.getPlugins().withType(BintrayPlugin.class, new Action<BintrayPlugin>() {
                     public void execute(BintrayPlugin bintrayPlugin) {
-                        Task bintrayUpload = project.getTasks().getByName(BintrayPlugin.BINTRAY_UPLOAD_TASK);
+                        Task bintrayUpload = p.getTasks().getByName(BintrayPlugin.BINTRAY_UPLOAD_TASK);
                         bintrayUploadAll.dependsOn(bintrayUpload);
+                        final BintrayExtension bintray = p.getExtensions().getByType(BintrayExtension.class);
+
+                        deferredConfiguration(p, new Runnable() {
+                            public void run() {
+                                final String bintrayRepo = bintray.getPkg().getRepo();
+                                configurePublicationRepo(project, bintrayRepo);
+                            }
+                        });
                     }
                 });
             }
@@ -142,5 +154,20 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                 });
             }
         });
+    }
+
+    private void configurePublicationRepo(Project project, String bintrayRepo) {
+        //not using 'getTasks().withType()' because I don't want to create too many task configuration rules
+        //TODO add information about it in the development guide
+        for (Task t : project.getTasks()) {
+            if (t instanceof IncrementalReleaseNotes) {
+                LOG.info("Configuring publication repository: {} on task: {}", bintrayRepo, t.getPath());
+                IncrementalReleaseNotes task = (IncrementalReleaseNotes) t;
+                if (task.getPublicationRepository() != null) {
+                    task.setPublicationRepository(bintrayRepo);
+                }
+            }
+        }
+        //TODO unit test coverage
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
@@ -7,12 +7,13 @@ import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 import org.mockito.release.gradle.IncrementalReleaseNotes;
 import org.mockito.release.gradle.ReleaseConfiguration;
-import org.mockito.release.internal.gradle.configuration.DeferredConfiguration;
 import org.mockito.release.internal.gradle.util.TaskMaker;
+import org.mockito.release.version.VersionInfo;
 
 import java.io.File;
 
 import static java.util.Collections.singletonList;
+import static org.mockito.release.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
 import static org.mockito.release.internal.gradle.configuration.LazyConfiguration.lazyConfiguration;
 
 /**
@@ -31,7 +32,7 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
 
     public void apply(final Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
-
+        project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(ContributorsPlugin.class);
 
         TaskMaker.task(project, "updateReleaseNotes", IncrementalReleaseNotes.UpdateTask.class, new Action<IncrementalReleaseNotes.UpdateTask>() {
@@ -76,11 +77,13 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
                 });
             }
         });
+
+        configureNotableReleaseNotes(project);
     }
 
     private static void preconfigureIncrementalNotes(final IncrementalReleaseNotes task, final Project project, final ReleaseConfiguration conf) {
         task.dependsOn("fetchContributorsFromGitHub");
-        DeferredConfiguration.deferredConfiguration(project, new Runnable() {
+        deferredConfiguration(project, new Runnable() {
             public void run() {
                 task.setGitHubLabelMapping(conf.getReleaseNotes().getLabelMapping()); //TODO make it optional
                 task.setReleaseNotesFile(project.file(conf.getReleaseNotes().getFile())); //TODO add sensible default
@@ -121,5 +124,23 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
                 return false;
             }
         });
+    }
+
+    private static void configureNotableReleaseNotes(Project project) {
+        //TODO when we make notable release notes optional, we can push that to a separate plugin
+        //like notable-release-notes plugin or something like that
+        //this way, the normal detailed release notes do not depend on versioning plugin
+        //and our plugins are more flexible
+        VersionInfo versionInfo = project.getExtensions().getByType(VersionInfo.class);
+        NotableReleaseNotesGeneratorTask generatorTask = (NotableReleaseNotesGeneratorTask) project.getTasks().getByName("updateNotableReleaseNotes");
+        NotableReleaseNotesFetcherTask fetcherTask = (NotableReleaseNotesFetcherTask) project.getTasks().getByName("fetchNotableReleaseNotes");
+
+        generatorTask.getNotesGeneration().setTargetVersions(versionInfo.getNotableVersions());
+        fetcherTask.getNotesGeneration().setTargetVersions(versionInfo.getNotableVersions());
+
+        if (versionInfo.isNotableRelease()) {
+            generatorTask.getNotesGeneration().setHeadVersion(project.getVersion().toString());
+            fetcherTask.getNotesGeneration().setHeadVersion(project.getVersion().toString());
+        }
     }
 }

--- a/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
+++ b/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
@@ -67,7 +67,7 @@ class GitNotesBuilder implements NotesBuilder {
         Collection<Improvement> improvements = improvementsProvider.getImprovements(contributions, Collections.<String>emptyList(), false);
 
         ReleaseNotesData data = new DefaultReleaseNotesData(version, new Date(), contributions, improvements, contributors, fromRevision, toRevision);
-        SingleReleaseNotesFormatter formatter = ReleaseNotesFormatters.defaultFormatter(labels);
+        SingleReleaseNotesFormatter formatter = ReleaseNotesFormatters.defaultFormatter(labels, publicationRepository);
 
         return formatter.formatVersion(data);
     }

--- a/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
+++ b/src/main/groovy/org/mockito/release/notes/GitNotesBuilder.java
@@ -48,7 +48,8 @@ class GitNotesBuilder implements NotesBuilder {
         this.authToken = authToken;
     }
 
-    public String buildNotes(String version, String fromRevision, String toRevision, final Map<String, String> labels) {
+    public String buildNotes(String version, String fromRevision, String toRevision, final Map<String, String> labels,
+                             String publicationRepository) {
         LOG.info("Getting release notes between {} and {}", fromRevision, toRevision);
 
         ProcessRunner processRunner = Exec.getProcessRunner(workDir);

--- a/src/main/groovy/org/mockito/release/notes/NotesBuilder.java
+++ b/src/main/groovy/org/mockito/release/notes/NotesBuilder.java
@@ -9,11 +9,12 @@ public interface NotesBuilder {
 
     /**
      * Release notes text for contributions between given versions.
-     *
-     * @param version the version of the release we're building the notes
+     *  @param version the version of the release we're building the notes
      * @param fromRevision valid git revision (can be tag name or HEAD)
      * @param toRevision valid git revision (can be tag name or HEAD)
      * @param labels GitHub/Issue tracker labels to caption mapping
+     * @param publicationRepository where binaries were published to
      */
-    String buildNotes(String version, String fromRevision, String toRevision, Map<String, String> labels);
+    String buildNotes(String version, String fromRevision, String toRevision, Map<String, String> labels,
+                      String publicationRepository);
 }

--- a/src/main/groovy/org/mockito/release/notes/format/DefaultFormatter.java
+++ b/src/main/groovy/org/mockito/release/notes/format/DefaultFormatter.java
@@ -83,8 +83,10 @@ class DefaultFormatter implements SingleReleaseNotesFormatter {
     private String format(ContributionSet contributions, ContributorsSet contributorsSet) {
         StringBuilder sb = new StringBuilder("* Authors: ")
                 .append(contributions.getContributions().size())
-                .append("\n* Commits: ")
-                .append(contributions.getAllCommits().size());
+                .append(", commits: ")
+                .append(contributions.getAllCommits().size())
+                .append(", published to: ")
+                .append(publicationRepository);
 
         for (Contribution c : contributions.getContributions()) {
             Contributor contributor = contributorsSet.findByAuthorName(c.getAuthorName());

--- a/src/main/groovy/org/mockito/release/notes/format/DefaultFormatter.java
+++ b/src/main/groovy/org/mockito/release/notes/format/DefaultFormatter.java
@@ -16,9 +16,11 @@ import java.util.Set;
 class DefaultFormatter implements SingleReleaseNotesFormatter {
 
     private final Map<String, String> labelMapping;
+    private final String publicationRepository;
 
-    DefaultFormatter(Map<String, String> labelMapping) {
+    DefaultFormatter(Map<String, String> labelMapping, String publicationRepository) {
         this.labelMapping = labelMapping;
+        this.publicationRepository = publicationRepository;
     }
 
     String format(Map<String, String> labels, Collection<Improvement> improvements) {

--- a/src/main/groovy/org/mockito/release/notes/format/ReleaseNotesFormatters.java
+++ b/src/main/groovy/org/mockito/release/notes/format/ReleaseNotesFormatters.java
@@ -16,8 +16,9 @@ public class ReleaseNotesFormatters {
      * In final release notes we want descriptive sections of improvements.
      * Mappings also allow controlling priority in presenting improvements -
      *  the formatter can use the order of label mappings. For example, 'noteworthy' labelled improvements on top.
+     * @param publicationRepository where the binaries were published to
      */
-    public static SingleReleaseNotesFormatter defaultFormatter(Map<String, String> labelMapping) {
+    public static SingleReleaseNotesFormatter defaultFormatter(Map<String, String> labelMapping, String publicationRepository) {
         return new DefaultFormatter(labelMapping);
     }
 

--- a/src/main/groovy/org/mockito/release/notes/format/ReleaseNotesFormatters.java
+++ b/src/main/groovy/org/mockito/release/notes/format/ReleaseNotesFormatters.java
@@ -19,7 +19,7 @@ public class ReleaseNotesFormatters {
      * @param publicationRepository where the binaries were published to
      */
     public static SingleReleaseNotesFormatter defaultFormatter(Map<String, String> labelMapping, String publicationRepository) {
-        return new DefaultFormatter(labelMapping);
+        return new DefaultFormatter(labelMapping, publicationRepository);
     }
 
     /**

--- a/src/test/groovy/org/mockito/release/notes/format/DefaultFormatterTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/format/DefaultFormatterTest.groovy
@@ -83,8 +83,7 @@ class DefaultFormatterTest extends Specification {
         def contributors = new DefaultContributorsSet()
 
         expect:
-        f.format(contributions, contributors) == """* Authors: 2
-* Commits: 3
+        f.format(contributions, contributors) == """* Authors: 2, commits: 3, published to: someRepo
   * 2: CD Drone
   * 1: Monalisa Octocat"""
     }
@@ -101,8 +100,7 @@ class DefaultFormatterTest extends Specification {
         contributors.addContributor(new DefaultContributor("CD Drone", "cddrone", "http://gh.com/cddrone"))
 
         expect:
-        f.format(contributions, contributors) == """* Authors: 2
-* Commits: 3
+        f.format(contributions, contributors) == """* Authors: 2, commits: 3, published to: someRepo
   * 2: [CD Drone](http://gh.com/cddrone)
   * 1: [Monalisa Octocat](http://gh.com/octocat)"""
     }
@@ -112,7 +110,7 @@ class DefaultFormatterTest extends Specification {
         def contributors = new DefaultContributorsSet()
 
         expect:
-        f.format(contributions, contributors) == "* Authors: 0\n* Commits: 0"
+        f.format(contributions, contributors) == "* Authors: 0, commits: 0, published to: someRepo"
     }
 
     def "contributions by same author with different email, no profile URLs"() {
@@ -126,8 +124,7 @@ class DefaultFormatterTest extends Specification {
         def contributors = new DefaultContributorsSet()
 
         expect:
-        f.format(contributions, contributors) == """* Authors: 2
-* Commits: 4
+        f.format(contributions, contributors) == """* Authors: 2, commits: 4, published to: someRepo
   * 3: john
   * 1: x"""
     }
@@ -145,8 +142,7 @@ class DefaultFormatterTest extends Specification {
         contributors.addContributor(new DefaultContributor("x", "x", "gh/x"))
 
         expect:
-        f.format(contributions, contributors) == """* Authors: 2
-* Commits: 4
+        f.format(contributions, contributors) == """* Authors: 2, commits: 4, published to: someRepo
   * 3: [john](gh/johnx)
   * 1: [x](gh/x)"""
     }
@@ -163,8 +159,7 @@ class DefaultFormatterTest extends Specification {
         def contributors = new DefaultContributorsSet()
 
         expect:
-        f.format(contributions, contributors) == """* Authors: 4
-* Commits: 5
+        f.format(contributions, contributors) == """* Authors: 4, commits: 5, published to: someRepo
   * 2: d
   * 1: a
   * 1: B
@@ -187,8 +182,7 @@ class DefaultFormatterTest extends Specification {
         contributors.addContributor(new DefaultContributor("a", "aa", "gh/aa"))
 
         expect:
-        f.format(contributions, contributors) == """* Authors: 4
-* Commits: 5
+        f.format(contributions, contributors) == """* Authors: 4, commits: 5, published to: someRepo
   * 2: [d](gh/dd)
   * 1: [a](gh/aa)
   * 1: [B](gh/BB)
@@ -205,8 +199,7 @@ class DefaultFormatterTest extends Specification {
 
         then: notes == """### 2.0.1 (2017-01-04)
 
-* Authors: 1
-* Commits: 1
+* Authors: 1, commits: 1, published to: someRepo
   * 1: a
 * Improvements: 1
   * Fix bug x [(#100)](http://issues/100)

--- a/src/test/groovy/org/mockito/release/notes/format/DefaultFormatterTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/format/DefaultFormatterTest.groovy
@@ -2,17 +2,17 @@ package org.mockito.release.notes.format
 
 import org.mockito.release.notes.contributors.DefaultContributor
 import org.mockito.release.notes.contributors.DefaultContributorsSet
-import org.mockito.release.notes.internal.DefaultReleaseNotesData
 import org.mockito.release.notes.internal.DefaultImprovement
-import org.mockito.release.notes.util.Predicate
+import org.mockito.release.notes.internal.DefaultReleaseNotesData
 import org.mockito.release.notes.model.ContributionSet
+import org.mockito.release.notes.util.Predicate
 import org.mockito.release.notes.vcs.DefaultContributionSet
 import org.mockito.release.notes.vcs.GitCommit
 import spock.lang.Specification
 
 class DefaultFormatterTest extends Specification {
 
-    DefaultFormatter f = new DefaultFormatter([:])
+    DefaultFormatter f = new DefaultFormatter([:], "someRepo")
 
     def "empty improvements"() {
         expect:


### PR DESCRIPTION
Continuous Delivery Pipeline 2.0 (https://github.com/mockito/mockito/issues/911) requires the release notes to include the information where the binaries were published to.

This PR is a first step, it adds the target repository to the notes. Next step is to format it and make it a link so that users can navigate to the repository to find binaries. The PR addresses issue https://github.com/mockito/mockito-release-tools/issues/4.

Tested with mockito project:
```
### 2.8.8 (2017-04-25)

* Authors: 1, commits: 2, published to: maven
  * 2: [Szczepan Faber](https://github.com/szczepiq)
* No notable improvements. See the commits for detailed changes.
```