### PR TITLE
New 'notableRelease' public API, new task 'testRelease'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.7.6'
+version = '0.8.0'
 
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -1,6 +1,7 @@
 package org.mockito.release.gradle;
 
 import org.gradle.api.GradleException;
+import org.mockito.release.version.VersionInfo;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ public class ReleaseConfiguration {
     private final ReleaseNotes releaseNotes = new ReleaseNotes();
     private final Git git = new Git();
     private final Team team = new Team();
+    private boolean notableRelease;
 
     public ReleaseConfiguration() {
         //Configure default values
@@ -64,6 +66,21 @@ public class ReleaseConfiguration {
 
     public Team getTeam() {
         return team;
+    }
+
+    /**
+     * See {@link #isNotableRelease()}
+     */
+    public void setNotableRelease(boolean notableRelease) {
+        this.notableRelease = notableRelease;
+    }
+
+    /**
+     * Informs if the release is considered 'notable' release.
+     * See {@link VersionInfo#isNotableRelease()}
+     */
+    public boolean isNotableRelease() {
+        return notableRelease;
     }
 
     public class GitHub {

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -34,6 +34,8 @@ public class ReleaseConfiguration {
         team.setAddContributorsToPomFromGitHub(true);
     }
 
+    //TODO currently it's not clear when to use class fields and when to use the 'configuration' map
+    //Let's make it clear in the docs
     private boolean dryRun = true;
 
     /**

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -34,10 +34,18 @@ public class ReleaseConfiguration {
 
     private boolean dryRun = true;
 
+    /**
+     * See {@link #isDryRun()}
+     */
     public void setDryRun(boolean dryRun) {
         this.dryRun = dryRun;
     }
 
+    /**
+     * If the release steps should be invoked in "dry run" mode.
+     * Relevant only to some kinds of release steps,
+     * such as bintray upload, git push.
+     */
     public boolean isDryRun() {
         return dryRun;
     }

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -1,7 +1,6 @@
 package org.mockito.release.gradle;
 
 import org.gradle.api.GradleException;
-import org.mockito.release.version.VersionInfo;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -78,7 +77,7 @@ public class ReleaseConfiguration {
 
     /**
      * Informs if the release is considered 'notable' release.
-     * See {@link VersionInfo#isNotableRelease()}
+     * See {@link org.mockito.release.version.VersionInfo#isNotableRelease()}
      */
     public boolean isNotableRelease() {
         return notableRelease;

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -24,13 +24,14 @@ public class ReleaseConfiguration {
     private final ReleaseNotes releaseNotes = new ReleaseNotes();
     private final Git git = new Git();
     private final Team team = new Team();
+    private final Build build = new Build();
+
     private boolean notableRelease;
 
     public ReleaseConfiguration() {
         //Configure default values
         git.setTagPrefix("v"); //so that tags are "v1.0", "v2.3.4"
         git.setReleasableBranchRegex("master|release/.+");  // matches 'master', 'release/2.x', 'release/3.x', etc.
-        git.setCommitMessagePostfix("[ci skip]");
         team.setAddContributorsToPomFromGitHub(true);
     }
 
@@ -81,6 +82,66 @@ public class ReleaseConfiguration {
      */
     public boolean isNotableRelease() {
         return notableRelease;
+    }
+
+    /**
+     * Settings of the current build job.
+     * Typically they are inferred from env variables
+     */
+    public Build getBuild() {
+        return build;
+    }
+
+    /**
+     * Settings for the current build job.
+     */
+    public class Build {
+
+        private String commitMessage;
+        private boolean pullRequest;
+
+        /**
+         * Commit message of the commit that triggered the job
+         */
+        public String getCommitMessage() {
+            return commitMessage;
+        }
+
+        /**
+         * See {@link #getCommitMessage()}
+         */
+        public void setCommitMessage(String commitMessage) {
+            this.commitMessage = commitMessage;
+        }
+
+        /**
+         * Whether this Travis job is a pull request build
+         */
+        public boolean isPullRequest() {
+            return pullRequest;
+        }
+
+        /**
+         * See {@link #isPullRequest()}
+         */
+        public void setPullRequest(boolean pullRequest) {
+            this.pullRequest = pullRequest;
+        }
+
+        /**
+         * Get the Git branch this Travis job is building.
+         * Will be used to commit / push code to.
+         */
+        public String getBranch() {
+            return getString("build.branch");
+        }
+
+        /**
+         * See {@link #getBranch()}
+         */
+        public void setBranch(String branch) {
+            configuration.put("build.branch", branch);
+        }
     }
 
     public class GitHub {
@@ -247,25 +308,6 @@ public class ReleaseConfiguration {
          */
         public void setReleasableBranchRegex(String releasableBranchRegex) {
             configuration.put("git.releasableBranchRegex", releasableBranchRegex);
-        }
-
-        /**
-         * See {@link #getBranch()}
-         */
-        public void setBranch(String branch) {
-            configuration.put("git.branch", branch);
-        }
-
-        /**
-         * Returns the branch the release process works on and commits code to.
-         * If not specified, it will be loaded from "TRAVIS_BRANCH" environment variable.
-         */
-        public String getBranch() {
-            //TODO decouple from Travis. Suggested plan:
-            //1. We remove the 'branch' configuration from here completely
-            //2. We add a utility method that gives us current branch, it should trigger the "git call" only once.
-            //3. We call that utility method if we need branch
-            return getString("git.branch", "TRAVIS_BRANCH");
         }
 
         /**

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -27,6 +27,7 @@ public class ReleaseNeededTask extends DefaultTask {
     private String releasableBranchRegex;
     private String commitMessage;
     private boolean pullRequest;
+    private boolean explosive;
 
     /**
      * The branch we currently operate on
@@ -84,6 +85,21 @@ public class ReleaseNeededTask extends DefaultTask {
         this.pullRequest = pullRequest;
     }
 
+    /**
+     * If the exception should be thrown if the release is not needed.
+     */
+    public boolean isExplosive() {
+        return explosive;
+    }
+
+    /**
+     * See {@link #isExplosive()}
+     */
+    public ReleaseNeededTask setExplosive(boolean explosive) {
+        this.explosive = explosive;
+        return this;
+    }
+
     @TaskAction public void releaseNeeded() {
         boolean skipEnvVariable = System.getenv(SKIP_RELEASE_ENV) != null;
         boolean skippedByCommitMessage = commitMessage != null && commitMessage.contains(SKIP_RELEASE_KEYWORD);
@@ -99,7 +115,8 @@ public class ReleaseNeededTask extends DefaultTask {
                 "\n    - is pull request build:  " + pullRequest +
                 "\n    - is releasable branch:  " + releasableBranch;
 
-        if (notNeeded) {
+        //TODO SF worth unit testing in some way :)
+        if (notNeeded && explosive) {
             throw new GradleException(message);
         } else {
             LOG.lifecycle(message);

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -13,22 +13,20 @@ import org.gradle.api.tasks.TaskAction;
  *  - the commit message, loaded from 'TRAVIS_COMMIT_MESSAGE' env variable contains '[ci skip-release]' keyword
  *  - the env variable 'TRAVIS_PULL_REQUEST' is not empty, not an empty String and and not 'false'
  *  - the branch ({@link #getBranch()} does not match release-eligibility regex ({@link #getReleasableBranchRegex()}.
+ *
+ *  TODO update the javadoc
  */
 public class ReleaseNeededTask extends DefaultTask {
 
     private final static Logger LOG = Logging.getLogger(ReleaseNeededTask.class);
 
-    //TODO we should consider exposing the configuration below in the ReleaseConfiguration
-    //For example, 'releasing.git.commit.message', 'releasing.git.commit.skipReleaseKeyword', 'releasing.skip', 'releasing.git.pullRequest'
-    //Goal: have all configuration in the extension object, have all env variable handling there for centralized documentation
-
     private final static String SKIP_RELEASE_ENV = "SKIP_RELEASE";
-    private final static String COMMIT_MESSAGE_ENV = "TRAVIS_COMMIT_MESSAGE";
-    private final static String PULL_REQUEST_ENV = "TRAVIS_PULL_REQUEST";
     private final static String SKIP_RELEASE_KEYWORD = "[ci skip-release]";
 
     private String branch;
     private String releasableBranchRegex;
+    private String commitMessage;
+    private boolean pullRequest;
 
     /**
      * The branch we currently operate on
@@ -58,17 +56,38 @@ public class ReleaseNeededTask extends DefaultTask {
         this.releasableBranchRegex = releasableBranchRegex;
     }
 
+    /**
+     * Commit message the build job was triggered with
+     */
+    public String getCommitMessage() {
+        return commitMessage;
+    }
+
+    /**
+     * See {@link #getCommitMessage()}
+     */
+    public void setCommitMessage(String commitMessage) {
+        this.commitMessage = commitMessage;
+    }
+
+    /**
+     * Pull request this job is building
+     */
+    public boolean isPullRequest() {
+        return pullRequest;
+    }
+
+    /**
+     * See {@link #isPullRequest()}
+     */
+    public void setPullRequest(boolean pullRequest) {
+        this.pullRequest = pullRequest;
+    }
+
     @TaskAction public void releaseNeeded() {
         boolean skipEnvVariable = System.getenv(SKIP_RELEASE_ENV) != null;
-        String commitMessage = System.getenv(COMMIT_MESSAGE_ENV);
         boolean skippedByCommitMessage = commitMessage != null && commitMessage.contains(SKIP_RELEASE_KEYWORD);
-
-        //returns true only if pull request env variable points to PR number
-        String pr = System.getenv(PULL_REQUEST_ENV);
-        boolean pullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
-
         boolean releasableBranch = branch != null && branch.matches(releasableBranchRegex);
-
         boolean notNeeded = skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch;
 
         //TODO add more color to the message

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -181,9 +181,15 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
             }
         });
 
+        //Task that throws an exception when release is not needed is very useful for CI workflows
+        //Travis CI job will stop executing further commands if assertReleaseNeeded fails.
+        //See the example projects how we have set up the 'assertReleaseNeeded' task in CI pipeline.
         releaseNeededTask(project, "assertReleaseNeeded", conf)
                 .setExplosive(true)
                 .setDescription("Asserts that criteria for the release are met and throws exception if release is not needed.");
+
+        //Below task is useful for testing. It will not throw an exception but will run the code that check is release is needed
+        //and it will print the information to the console.
         releaseNeededTask(project, "releaseNeeded", conf)
                 .setExplosive(false)
                 .setDescription("Checks and prints to the console if criteria for the release are met.");

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -28,6 +28,8 @@ import static org.mockito.release.internal.gradle.util.Specs.withName;
  *     <li>{@link ReleaseNotesPlugin}</li>
  *     <li>{@link VersioningPlugin}</li>
  *     <li>{@link GitPlugin}</li>
+ *     <li>{@link ContributorsPlugin}</li>
+ *     <li>{@link TravisPlugin}</li>
  * </ul>
  *
  * Adds following tasks:

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -166,7 +166,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
 
                 LazyConfiguration.lazyConfiguration(t, new Runnable() {
                     public void run() {
-                        t.setBranch(conf.getGit().getBranch());
+                        t.setBranch(conf.getBuild().getBranch());
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -48,6 +48,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
         project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(GitPlugin.class);
         project.getPlugins().apply(ContributorsPlugin.class);
+        project.getPlugins().apply(TravisPlugin.class);
 
         project.allprojects(new Action<Project>() {
             @Override
@@ -153,13 +154,6 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                 //using finalizedBy so that all clean up tasks run, even if one of them fails
                 t.finalizedBy(GitPlugin.COMMIT_CLEANUP_TASK);
                 t.finalizedBy(GitPlugin.TAG_CLEANUP_TASK);
-            }
-        });
-
-        TaskMaker.task(project, "travisReleasePrepare", new Action<Task>() {
-            public void execute(Task t) {
-                t.setDescription("Prepares the working copy for releasing using Travis CI");
-                t.dependsOn(GitPlugin.UNSHALLOW_TASK, GitPlugin.CHECKOUT_BRANCH_TASK, GitPlugin.SET_USER_TASK, GitPlugin.SET_EMAIL_TASK);
             }
         });
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/GitPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/GitPlugin.java
@@ -119,7 +119,7 @@ public class GitPlugin implements Plugin<Project> {
                 t.setDescription("Checks out the branch that can be committed. CI systems often check out revision that is not committable.");
                 lazyConfiguration(t, new Runnable() {
                     public void run() {
-                        t.commandLine("git", "checkout", conf.getGit().getBranch());
+                        t.commandLine("git", "checkout", conf.getBuild().getBranch());
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPlugin.java
@@ -3,6 +3,7 @@ package org.mockito.release.internal.gradle;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.mockito.release.gradle.ReleaseConfiguration;
+import org.mockito.release.version.VersionInfo;
 
 /**
  * Adds extension for configuring the release to the root project.
@@ -20,6 +21,9 @@ public class ReleaseConfigurationPlugin implements Plugin<Project> {
     public void apply(Project project) {
         if (project.getParent() == null) {
             //root project, add the extension
+            project.getPlugins().apply(VersioningPlugin.class);
+            VersionInfo info = project.getExtensions().getByType(VersionInfo.class);
+
             configuration = project.getRootProject().getExtensions()
                     .create("releasing", ReleaseConfiguration.class);
 
@@ -29,6 +33,8 @@ public class ReleaseConfigurationPlugin implements Plugin<Project> {
                 //TODO we can actually implement it so that we automatically preconfigure everything by command line parameters
                 //e.g. releasing.gitHub.repository is also a property
             }
+
+            configuration.setNotableRelease(info.isNotableRelease());
         } else {
             //not root project, get extension from root project
             configuration = project.getRootProject().getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPlugin.java
@@ -8,10 +8,11 @@ import org.mockito.release.version.VersionInfo;
 /**
  * Adds extension for configuring the release to the root project.
  * Important: it will add to the root project because this is where the configuration belong to!
- * <p>
- * Adds extensions:
+ * Adds following behavior:
  * <ul>
- *     <li>releasing - {@link ReleaseConfiguration}</li>
+ *     <li>Adds and preconfigures 'releasing' extension of type {@link ReleaseConfiguration}</li>
+ *     <li>Configures 'releasing.dryRun' setting based on 'releasing.dryRun' Gradle project property</li>
+ *     <li>Configures 'releasing.notableRelease' setting based on the version we are currently building</li>
  * </ul>
  */
 public class ReleaseConfigurationPlugin implements Plugin<Project> {

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
@@ -105,7 +105,7 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
         gen.setGitHubRepository(conf.getGitHub().getRepository());
         gen.setOutputFile(project.file(conf.getReleaseNotes().getNotableFile()));
         gen.setVcsCommitsLinkTemplate("https://github.com/" + conf.getGitHub().getRepository() + "/compare/{0}...{1}");
-        gen.setDetailedReleaseNotesLink(conf.getGitHub().getRepository() + "/blob/" + conf.getGit().getBranch() + "/" + conf.getReleaseNotes().getNotableFile());
+        gen.setDetailedReleaseNotesLink(conf.getGitHub().getRepository() + "/blob/" + conf.getBuild().getBranch() + "/" + conf.getReleaseNotes().getNotableFile());
     }
 
     private static File getTemporaryReleaseNotesFile(Project project){

--- a/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
@@ -1,0 +1,30 @@
+package org.mockito.release.internal.gradle;
+
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.mockito.release.internal.gradle.util.TaskMaker;
+
+/**
+ * Configures the release automation to be used with Travis CI.
+ * Adds tasks:
+ *
+ * <ul>
+ *     <li>'travisReleasePrepare' - Prepares the working copy for releasing using Travis CI</li>
+ * </ul>
+ */
+public class TravisPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPlugins().apply(GitPlugin.class);
+
+        TaskMaker.task(project, "travisReleasePrepare", new Action<Task>() {
+            public void execute(Task t) {
+                t.setDescription("Prepares the working copy for releasing using Travis CI");
+                t.dependsOn(GitPlugin.UNSHALLOW_TASK, GitPlugin.CHECKOUT_BRANCH_TASK, GitPlugin.SET_USER_TASK, GitPlugin.SET_EMAIL_TASK);
+            }
+        });
+    }
+}

--- a/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
@@ -36,6 +36,12 @@ public class TravisPlugin implements Plugin<Project> {
 
         conf.getBuild().setCommitMessage(System.getenv("TRAVIS_COMMIT_MESSAGE"));
         conf.getBuild().setBranch(System.getenv("TRAVIS_BRANCH"));
+        //TODO until we implement logic that gets the current branch we require to set TRAVIS_BRANCH even for local testing
+        //This is very annoying.
+        //We should create a utilty class/method (GitUtil) that identifies the branch by forking off git process.
+        //This needs to be synchronized and needs to happen only once.
+        //The utility method should use the build.branch setting but if it is not provided, get it from git
+
         conf.getBuild().setPullRequest(isPullRequest);
 
         TaskMaker.task(project, "travisReleasePrepare", new Action<Task>() {

--- a/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
@@ -4,10 +4,13 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.mockito.release.gradle.ReleaseConfiguration;
 import org.mockito.release.internal.gradle.util.TaskMaker;
 
 /**
  * Configures the release automation to be used with Travis CI.
+ * Preconfigures "releasing.build.*" settings based on Travis env variables.
+ * <p>
  * Adds tasks:
  *
  * <ul>
@@ -16,9 +19,27 @@ import org.mockito.release.internal.gradle.util.TaskMaker;
  */
 public class TravisPlugin implements Plugin<Project> {
 
+    private final static String COMMIT_MESSAGE_ENV = "TRAVIS_COMMIT_MESSAGE";
+    private final static String PULL_REQUEST_ENV = "TRAVIS_PULL_REQUEST";
+
     @Override
     public void apply(Project project) {
         project.getPlugins().apply(GitPlugin.class);
+        ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
+
+        String buildNo = System.getenv("TRAVIS_BUILD_NUMBER");
+        if (buildNo != null) {
+            conf.getGit().setCommitMessagePostfix("by Travis CI build " + buildNo + " [ci skip]");
+        } else {
+            conf.getGit().setCommitMessagePostfix("[ci skip]");
+        }
+
+        String pr = System.getenv(PULL_REQUEST_ENV);
+        boolean isPullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
+
+        conf.getBuild().setCommitMessage(System.getenv(COMMIT_MESSAGE_ENV));
+        conf.getBuild().setBranch(System.getenv("TRAVIS_BRANCH"));
+        conf.getBuild().setPullRequest(isPullRequest);
 
         TaskMaker.task(project, "travisReleasePrepare", new Action<Task>() {
             public void execute(Task t) {

--- a/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
@@ -19,9 +19,6 @@ import org.mockito.release.internal.gradle.util.TaskMaker;
  */
 public class TravisPlugin implements Plugin<Project> {
 
-    private final static String COMMIT_MESSAGE_ENV = "TRAVIS_COMMIT_MESSAGE";
-    private final static String PULL_REQUEST_ENV = "TRAVIS_PULL_REQUEST";
-
     @Override
     public void apply(Project project) {
         project.getPlugins().apply(GitPlugin.class);
@@ -34,10 +31,10 @@ public class TravisPlugin implements Plugin<Project> {
             conf.getGit().setCommitMessagePostfix("[ci skip]");
         }
 
-        String pr = System.getenv(PULL_REQUEST_ENV);
+        String pr = System.getenv("TRAVIS_PULL_REQUEST");
         boolean isPullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
 
-        conf.getBuild().setCommitMessage(System.getenv(COMMIT_MESSAGE_ENV));
+        conf.getBuild().setCommitMessage(System.getenv("TRAVIS_COMMIT_MESSAGE"));
         conf.getBuild().setBranch(System.getenv("TRAVIS_BRANCH"));
         conf.getBuild().setPullRequest(isPullRequest);
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/VersioningPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/VersioningPlugin.java
@@ -24,8 +24,6 @@ import java.io.File;
  * The plugin adds following extensions:
  *
  * <ul>
- *     <li>'project.ext.release_notable' boolean property
- *     that contains information if the current version is a notable release</li>
  *     <li>project.extensions.'org.mockito.release.version.VersionInfo' property
  *     of type {@link VersionInfo} that contains version information</li>
  * </ul>
@@ -40,7 +38,7 @@ public class VersioningPlugin implements Plugin<Project> {
     private static Logger LOG = Logging.getLogger(VersioningPlugin.class);
 
     public static final String VERSION_FILE_NAME = "version.properties";
-    public static final String FALLBACK_INITIAL_VERSION = "0.0.1";
+    private static final String FALLBACK_INITIAL_VERSION = "0.0.1";
 
     public void apply(Project project) {
         final File versionFile = project.file(VERSION_FILE_NAME);
@@ -50,7 +48,6 @@ public class VersioningPlugin implements Plugin<Project> {
         VersionInfo versionInfo = Version.versionInfo(versionFile);
 
         project.getExtensions().add(VersionInfo.class.getName(), versionInfo);
-        project.getExtensions().getExtraProperties().set("release_notable", versionInfo.isNotableRelease());
 
         final String version = versionInfo.getVersion();
         LOG.lifecycle("  Building version '{}' (value loaded from '{}' file).", version, versionFile.getName());

--- a/src/main/groovy/org/mockito/release/internal/gradle/VersioningPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/VersioningPlugin.java
@@ -40,7 +40,6 @@ public class VersioningPlugin implements Plugin<Project> {
     private static Logger LOG = Logging.getLogger(VersioningPlugin.class);
 
     public static final String VERSION_FILE_NAME = "version.properties";
-    public static final String GRADLE_DEFAULT_VERSION = "unspecified";
     public static final String FALLBACK_INITIAL_VERSION = "0.0.1";
 
     public void apply(Project project) {
@@ -85,7 +84,7 @@ public class VersioningPlugin implements Plugin<Project> {
     }
 
     private String determineVersion(Project project){
-        if(GRADLE_DEFAULT_VERSION.equals(project.getVersion()) ){
+        if("unspecified".equals(project.getVersion()) ){
             LOG.lifecycle("  BEWARE! Project.version is unspecified. Version will be set to {}. You can change it manually in version.properties.", FALLBACK_INITIAL_VERSION);
             return FALLBACK_INITIAL_VERSION;
         } else{

--- a/src/main/groovy/org/mockito/release/internal/gradle/util/GitUtil.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/util/GitUtil.java
@@ -22,7 +22,7 @@ public class GitUtil {
         String ghUser = conf.getGitHub().getWriteAuthUser();
         String ghWriteToken = conf.getGitHub().getWriteAuthToken();
         String ghRepo = conf.getGitHub().getRepository();
-        String branch = conf.getGit().getBranch();
+        String branch = conf.getBuild().getBranch();
         String url = MessageFormat.format("https://{0}:{1}@github.com/{2}.git", ghUser, ghWriteToken, ghRepo);
 
         ArrayList<String> args = new ArrayList<String>(asList("git", "push", url, branch, getTag(conf, project)));

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPluginTest.groovy
@@ -54,5 +54,19 @@ class ReleaseConfigurationPluginTest extends Specification {
         configuration.team.addContributorsToPomFromGitHub == false
     }
 
+    def "knows if the release is not notable"() {
+        def conf = root.plugins.apply(ReleaseConfigurationPlugin).configuration
 
+        expect: !conf.notableRelease
+
+        when: conf.notableRelease = true
+        then: conf.notableRelease
+    }
+
+    def "knows if the release is notable"() {
+        root.file("version.properties") << "version=1.5.0"
+
+        expect:
+        root.plugins.apply(ReleaseConfigurationPlugin).configuration.notableRelease
+    }
 }

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationTest.groovy
@@ -7,11 +7,6 @@ class ReleaseConfigurationTest extends Specification {
 
     def conf = new ReleaseConfiguration()
 
-    def "default commitMessagePostfix"() {
-        expect:
-        conf.git.commitMessagePostfix == "[ci skip]"
-    }
-
     def "custom commitMessagePostfix"() {
         //TODO figure out a test that would validate all properties with reflection
         //rather than implement individual unit test for each property (getter and setter)
@@ -19,5 +14,11 @@ class ReleaseConfigurationTest extends Specification {
 
         expect:
         conf.git.commitMessagePostfix ==  " by CI build 1234 [ci skip-release]"
+    }
+
+    def "empty build settings are ok"() {
+        expect:
+        conf.build.commitMessage == null
+        !conf.build.pullRequest
     }
 }

--- a/src/test/groovy/org/mockito/release/internal/gradle/VersioningPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/VersioningPluginTest.groovy
@@ -68,7 +68,6 @@ class VersioningPluginTest extends Specification {
         versionInfo.versionFile == project.file(VersioningPlugin.VERSION_FILE_NAME)
         versionInfo.version == "1.0.0"
         versionInfo.notableVersions == ["0.1.0"] as LinkedList
-
-        project.extensions.extraProperties.get("release_notable") == true
+        versionInfo.notableRelease
     }
 }


### PR DESCRIPTION
1. Replaced weak 'ext.notable_release' with decent 'releasing.notableRelease', part of the public API
2. Decoupled our plugins from Travis, put Travis related stuff in a separate plugin.
3. Added convenient 'testRelease' task that can be used for testing, made it so that it has decent coverage.
4. Refactorings and tidy-ups