### PR TITLE
Fixed mockito release bug by adding missing task configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-version = '0.8.0'
+version = '0.8.1'
 
 println "  Version: $version"
 group = 'gradle.plugin.org.mockito'

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -102,13 +102,19 @@ public class ReleaseNeededTask extends DefaultTask {
 
     @TaskAction public void releaseNeeded() {
         boolean skipEnvVariable = System.getenv(SKIP_RELEASE_ENV) != null;
-        boolean skippedByCommitMessage = commitMessage != null && commitMessage.contains(SKIP_RELEASE_KEYWORD);
+        LOG.lifecycle("  Environment variable {} present: {}", SKIP_RELEASE_ENV, skipEnvVariable);
+
+        boolean commitMessageEmpty = commitMessage == null || commitMessage.trim().isEmpty();
+        boolean skippedByCommitMessage = !commitMessageEmpty && commitMessage.contains(SKIP_RELEASE_KEYWORD);
+        LOG.lifecycle("  Commit message to inspect for keyword '{}': {}",
+                SKIP_RELEASE_KEYWORD,
+                commitMessageEmpty? "<unknown commit message>" : "\n" + commitMessage);
+
         boolean releasableBranch = branch != null && branch.matches(releasableBranchRegex);
+        LOG.lifecycle("  Current branch '{}' matches '{}': {}", branch, releasableBranchRegex, releasableBranch);
+
         boolean notNeeded = skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch;
 
-        //TODO add more color to the message
-        //add env variable names, what is the current branch, what is the regexp, etc.
-        //This way it is easier to understand how stuff works by reading the log
         String message = "  Release is needed: " + !notNeeded +
                 "\n    - skip by env variable: " + skipEnvVariable +
                 "\n    - skip by commit message: " + skippedByCommitMessage +

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -201,6 +201,8 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                 t.setDescription("Asserts that criteria for the release are met and throws exception if release not needed.");
                 t.setReleasableBranchRegex(conf.getGit().getReleasableBranchRegex());
                 t.setExplosive(true);
+                t.setCommitMessage(conf.getBuild().getCommitMessage());
+                t.setPullRequest(conf.getBuild().isPullRequest());
 
                 lazyConfiguration(t, new Runnable() {
                     public void run() {


### PR DESCRIPTION
1. Fixed bug, added missing settings for release needed task. Fixes Mockito release bug mockito/mockito#1059 which I have planted myself :( We need integration tests!!!
2. Added more logging to the release needed task. It will make it easier to debug issues as above.

### Testing done

1. commit message keyword makes release not needed:

```
~/mockito/example-release$ export TRAVIS_COMMIT_MESSAGE="blah blah [ci skip-release]"
~/mockito/example-release$ 
~/mockito/example-release$ 
~/mockito/example-release$ ./gradlew releaseNeeded
  Using version '0.8.0' of Mockito Release Tools
  Building version '0.15.3' (value loaded from 'version.properties' file).
:releaseNeeded
  Environment variable SKIP_RELEASE present: false
  Commit message to inspect for keyword '[ci skip-release]': 
blah blah [ci skip-release]
  Current branch 'sf' matches 'master|release/.+': false
  Release is needed: false
    - skip by env variable: false
    - skip by commit message: true
    - is pull request build:  false
    - is releasable branch:  false
```

2. when building pull request, the release is not needed:

```
~/mockito/example-release$ export TRAVIS_PULL_REQUEST=123
~/mockito/example-release$ 
~/mockito/example-release$ ./gradlew releaseNeeded
  Using version '0.8.0' of Mockito Release Tools
  Building version '0.15.3' (value loaded from 'version.properties' file).
:releaseNeeded
  Environment variable SKIP_RELEASE present: false
  Commit message to inspect for keyword '[ci skip-release]': 
blah blah [ci skip-release]
  Current branch 'sf' matches 'master|release/.+': false
  Release is needed: false
    - skip by env variable: false
    - skip by commit message: true
    - is pull request build:  true
    - is releasable branch:  false

BUILD SUCCESSFUL
```