### PR TITLE
Release needed task changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ targetCompatibility = 1.6
 
 repositories { jcenter() }
 
-println "  Version: $version"
 group = 'gradle.plugin.org.mockito'
 
 dependencies {

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -143,7 +143,11 @@ public class ReleaseNeededTask extends DefaultTask {
         publicationsComparators.add(task);
     }
 
-    boolean areAllPublicationsEqual(){
+    boolean areAllPublicationsEqual() {
+        if (publicationsComparators.isEmpty()) {
+            return false;
+        }
+
         boolean allEqual = true;
 
         for(PublicationsComparator comparator : publicationsComparators){

--- a/src/test/groovy/org/mockito/release/gradle/ReleaseNeededTaskTest.groovy
+++ b/src/test/groovy/org/mockito/release/gradle/ReleaseNeededTaskTest.groovy
@@ -9,12 +9,12 @@ class ReleaseNeededTaskTest extends Specification {
 
     ReleaseNeededTask underTest = new ProjectBuilder().build().getTasks().create("releaseNeeded", ReleaseNeededTask)
 
-    def "allPublicationsEqual should be true if no PublicationComparisonTasks"() {
+    def "allPublicationsEqual should be false if no PublicationComparisonTasks"() {
         when:
         underTest.releaseNeeded()
 
         then:
-        underTest.areAllPublicationsEqual()
+        !underTest.areAllPublicationsEqual()
     }
 
     def "allPublicationsEqual should be true if all PublicationComparisonTasks return true"() {

--- a/version.properties
+++ b/version.properties
@@ -1,6 +1,6 @@
 #Version of the produced binaries. This file is intended to be checked-in.
 #It will be automatically bumped by release automation.
-version=0.8.6
+version=0.8.7
 
 #Last previous release version
 previousVersion=0.8.2


### PR DESCRIPTION
When the comparator tasks are not configured,
we will assume that we actually want to publish the release.
I think it is a safer default in case somebody wants to use the task
without configuring the comparator tasks.
However, the previous approach made sense, too.