### PR TITLE
#85 Automated e2e testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ gradle-app.setting
 # gradle/wrapper/gradle-wrapper.properties
 
 .idea
+
+# ignore projects for E2E testing, but not build.gradle
+e2eTests/
+!e2eTests/build.gradle

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,3 @@ gradle-app.setting
 # gradle/wrapper/gradle-wrapper.properties
 
 .idea
-
-# ignore projects for E2E testing, but not build.gradle
-e2eTests/
-!e2eTests/build.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
-        //TODO MS back to concrete version after finish
-        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.8.+"
+        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.8.32"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 // First, apply the publishing plugin
 buildscript {
     repositories {
-        mavenLocal()
+        mavenLocal()        // for e2e test
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
+        //TODO MS back to concrete version after finish
         classpath "gradle.plugin.org.mockito:mockito-release-tools:0.8.+"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 // First, apply the publishing plugin
 buildscript {
     repositories {
+        mavenLocal()
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
-        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.8.25"
+        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.8.+"
     }
 }
 
@@ -71,6 +72,12 @@ pluginBundle {
             id = 'org.mockito.mockito-release-tools.release-needed'
             displayName = 'Mockito plugin for checking if release is needed'
             tags = ['mockito', 'continuous delivery', 'release']
+        }
+
+        e2eTestPlugin {
+            id = 'org.mockito.mockito-release-tools.e2e-test'
+            displayName = 'Mockito e2e tests plugin'
+            tags = ['mockito', 'continuous delivery', 'release', 'e2e', 'end-to-end', 'end-2-end', 'test']
         }
     }
 

--- a/e2eTests/build.gradle
+++ b/e2eTests/build.gradle
@@ -1,0 +1,31 @@
+def e2eProjects = ["mockito-release-tools-example": "https://github.com/mockito/mockito-release-tools-example"]
+
+task e2eTest {
+    doFirst {
+        e2eProjects.each { entry ->
+            println "  E2E tests for $entry.key :)"
+            def key = entry.key
+            task e2eTest$key {
+                println "task $key"
+                //TODO not clone if exist or delete dir?
+                gitClone(key, e2eProjects[key]).execute()
+                //TODO b) bump version of producer to locally built
+                //TODO c) performRelease -Preleasing.dryRun
+            }
+        }
+    }
+}
+
+def gitClone(String projectName, String repoUrl) {
+    return tasks.create("gitClone$projectName", Exec) {
+        commandLine 'git', 'clone', "$repoUrl", "$projectDir/$projectName"
+    }
+}
+
+task check {
+    dependsOn e2eTest
+}
+
+task build {
+    dependsOn check
+}

--- a/e2eTests/build.gradle
+++ b/e2eTests/build.gradle
@@ -1,79 +1,13 @@
 apply plugin: 'base'    // for clean task
-apply plugin: 'org.mockito.mockito-release-tools.e2e-test'
 
-group = 'gradle.plugin.org.mockito'
-description = 'for running e2e tests'
-
-// org.gradle.language.base.plugins.LifecycleBasePlugin
-
-//def e2eProjects = ["mockito-release-tools-example": "https://github.com/mockito/mockito-release-tools-example"]
-
-//subprojects {
-//    tasks.create("e2eTest", E2ETestingPlugin.E2ETest) {
-//        create("https://github.com/mockito/mockito-release-tools-example")
-//    }
-//}
-
-//task e2eTest {
-//    doFirst {
-//        e2eProjects.each { entry ->
-//            println "  E2E tests for $entry.key :)"
-//            def projectName = entry.key
-//            task e2eTest$projectName {
-//                deleteProjectDir(projectName)
-//                gitClone(projectName, e2eProjects[projectName])
-//                bumpProjectVersion(projectName)
-//                performRelease(projectName)
-//            }
-//        }
-//    }
-//}
-//
-//def deleteProjectDir(String projectName) {
-//    tasks.create("deleteDir$projectName", Delete) {
-//        delete "$projectDir/$projectName"
-//    }.execute()
-//}
-//
-//def gitClone(String projectName, String repoUrl) {
-//    tasks.create("gitClone$projectName", Exec) {
-//        commandLine 'git', 'clone', "$repoUrl", "$projectDir/$projectName"
-//    }.execute()
-//}
-//
-//def bumpProjectVersion(String projectName) {
-//    ant.replaceregexp(
-//            match: "gradle\\.plugin\\.org\\.mockito:mockito-release-tools:(\\d+)?\\.(\\d+)?\\.(\\d+)?",
-//            replace: "gradle.plugin.org.mockito:mockito-release-tools:$project.version") {
-//        fileset(dir: "$projectDir/$projectName", includes: 'build.gradle gradle.properties')
-//    }
-//}
-//
-//def performRelease(String projectName) {
-//    println "  Testing the Gradle build..."
-//    exec {
-//        workingDir "$projectDir/$projectName"
-//        commandLine './gradlew', 'publishToMavenLocal', 'testRelease', '-x', 'gitPush', '-x', 'bintrayUpload'
-//    }
-//}
-
-//task check {
-//    dependsOn e2eTest
-//}
-//
-//task build {
-//    dependsOn check
-//}
+// It needs to be commented until first version of release-tools with E2E plugin is released.
+// If not, Gradle is unable to configure whole project, because E2E plugin isn't published in any version yet.
+// TODO uncomment in next PR
+// apply plugin: 'org.mockito.mockito-release-tools.e2e-test'
 
 /*
 
-I loooove the direction :) I was even able to run it locally when I did some tweaks to the code (pushed to your branch)
-
 Before we can push the code, I'd like to clean it up a little bit (TODO)
-1. Clone into build directory of the project, no need to tweak .idea
-    This also means that the cloned content will be automatically 'excluded' from indexing by IDEA
-2. Use imperative exec instead of task.execute()
-3. Task descriptions
 4. In order for Gradle to neatly paralelize,
 let's have the mockito and mockito-release-tools-example be separate subprojects,
 just like I have set it up in PR #100.

--- a/e2eTests/build.gradle
+++ b/e2eTests/build.gradle
@@ -9,7 +9,7 @@ task e2eTest {
                 deleteProjectDir(projectName)
                 gitClone(projectName, e2eProjects[projectName])
                 bumpProjectVersion(projectName)
-                //TODO c) performRelease -Preleasing.dryRun
+                performRelease(projectName)
             }
         }
     }
@@ -35,6 +35,12 @@ def bumpProjectVersion(String projectName) {
     }
 }
 
+def performRelease(String projectName) {
+    tasks.create("performRelease$projectName", Exec) {
+        workingDir "$projectDir/$projectName"
+        commandLine './gradlew', 'performRelease', '-Preleasing.dryRun'
+    }.execute()
+}
 
 task check {
     dependsOn e2eTest

--- a/e2eTests/build.gradle
+++ b/e2eTests/build.gradle
@@ -1,55 +1,65 @@
-def e2eProjects = ["mockito-release-tools-example": "https://github.com/mockito/mockito-release-tools-example"]
+apply plugin: 'org.mockito.mockito-release-tools.e2e-test'
 
-task e2eTest {
-    doFirst {
-        e2eProjects.each { entry ->
-            println "  E2E tests for $entry.key :)"
-            def projectName = entry.key
-            task e2eTest$projectName {
-                deleteProjectDir(projectName)
-                gitClone(projectName, e2eProjects[projectName])
-                bumpProjectVersion(projectName)
-                performRelease(projectName)
-            }
-        }
-    }
-}
 
-def deleteProjectDir(String projectName) {
-    tasks.create("deleteDir$projectName", Delete) {
-        delete "$projectDir/$projectName"
-    }.execute()
-}
 
-def gitClone(String projectName, String repoUrl) {
-    tasks.create("gitClone$projectName", Exec) {
-        commandLine 'git', 'clone', "$repoUrl", "$projectDir/$projectName"
-    }.execute()
-}
+//def e2eProjects = ["mockito-release-tools-example": "https://github.com/mockito/mockito-release-tools-example"]
 
-def bumpProjectVersion(String projectName) {
-    ant.replaceregexp(
-            match: "gradle\\.plugin\\.org\\.mockito:mockito-release-tools:(\\d+)?\\.(\\d+)?\\.(\\d+)?",
-            replace: "gradle.plugin.org.mockito:mockito-release-tools:$project.version") {
-        fileset(dir: "$projectDir/$projectName", includes: 'build.gradle gradle.properties')
-    }
-}
+//subprojects {
+//    tasks.create("e2eTest", E2ETestingPlugin.E2ETest) {
+//        create("https://github.com/mockito/mockito-release-tools-example")
+//    }
+//}
 
-def performRelease(String projectName) {
-    println "  Testing the Gradle build..."
-    exec {
-        workingDir "$projectDir/$projectName"
-        commandLine './gradlew', 'publishToMavenLocal', 'testRelease', '-x', 'gitPush', '-x', 'bintrayUpload'
-    }
-}
+//task e2eTest {
+//    doFirst {
+//        e2eProjects.each { entry ->
+//            println "  E2E tests for $entry.key :)"
+//            def projectName = entry.key
+//            task e2eTest$projectName {
+//                deleteProjectDir(projectName)
+//                gitClone(projectName, e2eProjects[projectName])
+//                bumpProjectVersion(projectName)
+//                performRelease(projectName)
+//            }
+//        }
+//    }
+//}
+//
+//def deleteProjectDir(String projectName) {
+//    tasks.create("deleteDir$projectName", Delete) {
+//        delete "$projectDir/$projectName"
+//    }.execute()
+//}
+//
+//def gitClone(String projectName, String repoUrl) {
+//    tasks.create("gitClone$projectName", Exec) {
+//        commandLine 'git', 'clone', "$repoUrl", "$projectDir/$projectName"
+//    }.execute()
+//}
+//
+//def bumpProjectVersion(String projectName) {
+//    ant.replaceregexp(
+//            match: "gradle\\.plugin\\.org\\.mockito:mockito-release-tools:(\\d+)?\\.(\\d+)?\\.(\\d+)?",
+//            replace: "gradle.plugin.org.mockito:mockito-release-tools:$project.version") {
+//        fileset(dir: "$projectDir/$projectName", includes: 'build.gradle gradle.properties')
+//    }
+//}
+//
+//def performRelease(String projectName) {
+//    println "  Testing the Gradle build..."
+//    exec {
+//        workingDir "$projectDir/$projectName"
+//        commandLine './gradlew', 'publishToMavenLocal', 'testRelease', '-x', 'gitPush', '-x', 'bintrayUpload'
+//    }
+//}
 
-task check {
-    dependsOn e2eTest
-}
-
-task build {
-    dependsOn check
-}
+//task check {
+//    dependsOn e2eTest
+//}
+//
+//task build {
+//    dependsOn check
+//}
 
 /*
 

--- a/e2eTests/build.gradle
+++ b/e2eTests/build.gradle
@@ -4,23 +4,37 @@ task e2eTest {
     doFirst {
         e2eProjects.each { entry ->
             println "  E2E tests for $entry.key :)"
-            def key = entry.key
-            task e2eTest$key {
-                println "task $key"
-                //TODO not clone if exist or delete dir?
-                gitClone(key, e2eProjects[key]).execute()
-                //TODO b) bump version of producer to locally built
+            def projectName = entry.key
+            task e2eTest$projectName {
+                deleteProjectDir(projectName)
+                gitClone(projectName, e2eProjects[projectName])
+                bumpProjectVersion(projectName)
                 //TODO c) performRelease -Preleasing.dryRun
             }
         }
     }
 }
 
+def deleteProjectDir(String projectName) {
+    tasks.create("deleteDir$projectName", Delete) {
+        delete "$projectDir/$projectName"
+    }.execute()
+}
+
 def gitClone(String projectName, String repoUrl) {
-    return tasks.create("gitClone$projectName", Exec) {
+    tasks.create("gitClone$projectName", Exec) {
         commandLine 'git', 'clone', "$repoUrl", "$projectDir/$projectName"
+    }.execute()
+}
+
+def bumpProjectVersion(String projectName) {
+    ant.replaceregexp(
+            match: "gradle\\.plugin\\.org\\.mockito:mockito-release-tools:(\\d+)?\\.(\\d+)?\\.(\\d+)?",
+            replace: "gradle.plugin.org.mockito:mockito-release-tools:$project.version") {
+        fileset(dir: "$projectDir/$projectName", includes: 'build.gradle gradle.properties')
     }
 }
+
 
 task check {
     dependsOn e2eTest

--- a/e2eTests/build.gradle
+++ b/e2eTests/build.gradle
@@ -1,6 +1,10 @@
+apply plugin: 'base'    // for clean task
 apply plugin: 'org.mockito.mockito-release-tools.e2e-test'
 
+group = 'gradle.plugin.org.mockito'
+description = 'for running e2e tests'
 
+// org.gradle.language.base.plugins.LifecycleBasePlugin
 
 //def e2eProjects = ["mockito-release-tools-example": "https://github.com/mockito/mockito-release-tools-example"]
 

--- a/e2eTests/build.gradle
+++ b/e2eTests/build.gradle
@@ -50,3 +50,28 @@ task check {
 task build {
     dependsOn check
 }
+
+/*
+
+I loooove the direction :) I was even able to run it locally when I did some tweaks to the code (pushed to your branch)
+
+Before we can push the code, I'd like to clean it up a little bit (TODO)
+1. Clone into build directory of the project, no need to tweak .idea
+    This also means that the cloned content will be automatically 'excluded' from indexing by IDEA
+2. Use imperative exec instead of task.execute()
+3. Task descriptions
+4. In order for Gradle to neatly paralelize,
+let's have the mockito and mockito-release-tools-example be separate subprojects,
+just like I have set it up in PR #100.
+This way, the integration tests will run in parallel (Gradle parallelizes per project)
+5. Let's have completely separate task for cloning which will be incremental
+    (e.g. does not clone twice when you run build twice).
+    The task that performs the test will copy from the files from the clone task into some work dir and execute the test there
+6. Let's use relatively shallow clone. We don't need all history.
+7. I think we're missing task dependency to root's 'publishToMavenLocal'
+
+Integration testing is a big feature of shipkit!
+We will morph it into a plugin that will be part of the release tools plugins.
+Take your time engineering it and learn as much Gradle as possible during the process :)
+
+ */

--- a/e2eTests/build.gradle
+++ b/e2eTests/build.gradle
@@ -36,10 +36,11 @@ def bumpProjectVersion(String projectName) {
 }
 
 def performRelease(String projectName) {
-    tasks.create("performRelease$projectName", Exec) {
+    println "  Testing the Gradle build..."
+    exec {
         workingDir "$projectDir/$projectName"
-        commandLine './gradlew', 'performRelease', '-Preleasing.dryRun'
-    }.execute()
+        commandLine './gradlew', 'publishToMavenLocal', 'testRelease', '-x', 'gitPush', '-x', 'bintrayUpload'
+    }
 }
 
 task check {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name="mockito-release-tools"
+
+include "e2eTests"

--- a/src/main/groovy/org/mockito/release/exec/DefaultProcessRunner.java
+++ b/src/main/groovy/org/mockito/release/exec/DefaultProcessRunner.java
@@ -3,6 +3,7 @@ package org.mockito.release.exec;
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.mockito.release.notes.util.IOUtil;
 import org.mockito.release.notes.util.ReleaseNotesException;
 
 import java.io.BufferedReader;
@@ -21,10 +22,24 @@ public class DefaultProcessRunner implements ProcessRunner {
 
     private static final Logger LOG = Logging.getLogger(DefaultProcessRunner.class);
     private final File workDir;
+    private final File outputLogFile;
     private String secretValue;
 
+    /**
+     * Calls {@link #DefaultProcessRunner(File, File)}
+     */
     public DefaultProcessRunner(File workDir) {
+        this(workDir, null);
+    }
+
+    /**
+     * Create Process runner
+     * @param workDir Work directory where to start a process
+     * @param outputLogFile If process create a long output it's better to save it in file
+     */
+    public DefaultProcessRunner(File workDir, File outputLogFile) {
         this.workDir = workDir;
+        this.outputLogFile = outputLogFile;
     }
 
     public String run(String... commandLine) {
@@ -43,9 +58,7 @@ public class DefaultProcessRunner implements ProcessRunner {
         ProcessResult result = executeProcess(commandLine, maskedCommandLine);
 
         if (result.getExitValue() != 0) {
-            throw new GradleException("Execution of command failed (exit code " + result.getExitValue() + "):\n" +
-                    "  " + maskedCommandLine + "\n" +
-                    "Captured command output:\n" + result.getOutput());
+            return executionOfCommandFailed(maskedCommandLine, result);
         } else {
             return result.getOutput();
         }
@@ -56,6 +69,7 @@ public class DefaultProcessRunner implements ProcessRunner {
         try {
             Process process = new ProcessBuilder(commandLine).directory(workDir).redirectErrorStream(true).start();
             String output = mask(readFully(new BufferedReader(new InputStreamReader(process.getInputStream()))));
+            storeOutputToFile(output);
 
             //TODO add sanity timeout when we move to Java 1.7
             // 1. we can do something like process.waitFor(15, TimeUnit.MINUTES)
@@ -87,6 +101,23 @@ public class DefaultProcessRunner implements ProcessRunner {
         } finally {
             reader.close();
         }
+    }
+
+    private void storeOutputToFile(String content) {
+        if(outputLogFile != null) {
+            IOUtil.writeFile(outputLogFile, content);
+        }
+    }
+
+    private String executionOfCommandFailed(String maskedCommandLine, ProcessResult result) {
+        String message = "Execution of command failed (exit code " + result.getExitValue() + "):\n" +
+                "  " + maskedCommandLine + "\n";
+        if(outputLogFile == null) {
+            message = message + "  Captured command output:\n" + result.getOutput();
+        } else {
+            message = message + "  Captured command output stored in " + outputLogFile;
+        }
+        throw new GradleException(message);
     }
 
     /**

--- a/src/main/groovy/org/mockito/release/exec/DefaultProcessRunner.java
+++ b/src/main/groovy/org/mockito/release/exec/DefaultProcessRunner.java
@@ -105,6 +105,8 @@ public class DefaultProcessRunner implements ProcessRunner {
 
     private void storeOutputToFile(String content) {
         if(outputLogFile != null) {
+            //TODO ms - can we make sure that the output does not have sensitive secret values
+            //should we mask secret values in the output stored in file, too?
             IOUtil.writeFile(outputLogFile, content);
         }
     }

--- a/src/main/groovy/org/mockito/release/exec/Exec.java
+++ b/src/main/groovy/org/mockito/release/exec/Exec.java
@@ -15,4 +15,11 @@ public class Exec {
     public static ProcessRunner getProcessRunner(File workDir) {
         return new DefaultProcessRunner(workDir);
     }
+
+    /**
+     * Provides process runner for given working dir
+     */
+    public static ProcessRunner getProcessRunner(File workDir, File outputLogFile) {
+        return new DefaultProcessRunner(workDir, outputLogFile);
+    }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/CloneGitRepositoryTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/CloneGitRepositoryTask.java
@@ -13,6 +13,12 @@ import java.io.File;
 /**
  * This task clone git project from repository to target dir.
  * It support clone from remote server and from local filesystem.
+ *
+ * TODO ms - when you are ready, please move the new task types to the public packages,
+ *   for example "org.mockito.release.*". With 1.0 we need all task types to be public.
+ *   It's because users interface with task types when they work with Gradle build scripts.
+ *   So it makes sense to be explicit that those types are public and we guarantee compatibility.
+ *   See also README.md on the compatibility where I attempted to describe this ;)
  */
 public class CloneGitRepositoryTask extends DefaultTask {
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/CloneGitRepositoryTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/CloneGitRepositoryTask.java
@@ -29,7 +29,7 @@ public class CloneGitRepositoryTask extends DefaultTask {
 
     @TaskAction
     public void cloneRepository() {
-        LOG.lifecycle("  Clone repository");
+        LOG.lifecycle("  Cloning repository {}\n    into {}", repository, targetDir);
         getProject().getBuildDir().mkdirs();    // build dir can be not created yet
         ProcessRunner processRunner = org.mockito.release.exec.Exec.getProcessRunner(getProject().getBuildDir());
         processRunner.run("git", "clone", repository, targetDir.getAbsolutePath());

--- a/src/main/groovy/org/mockito/release/internal/gradle/CloneGitRepositoryTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/CloneGitRepositoryTask.java
@@ -34,6 +34,10 @@ public class CloneGitRepositoryTask extends DefaultTask {
         this.repository = repository;
     }
 
+    public String getRepository() {
+        return repository;
+    }
+
     @OutputDirectory
     public void setTargetDir(File targetDir) {
         this.targetDir = targetDir;

--- a/src/main/groovy/org/mockito/release/internal/gradle/CloneGitRepositoryTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/CloneGitRepositoryTask.java
@@ -1,0 +1,45 @@
+package org.mockito.release.internal.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+import org.mockito.release.exec.ProcessRunner;
+
+import java.io.File;
+
+/**
+ * This task clone git project from repository to target dir.
+ * It support clone from remote server and from local filesystem.
+ */
+public class CloneGitRepositoryTask extends DefaultTask {
+
+    private static final Logger LOG = Logging.getLogger(CloneGitRepositoryTask.class);
+
+    private String repository;
+    private File targetDir;
+
+    @TaskAction
+    public void cloneRepository() {
+        LOG.lifecycle("  Clone repository");
+        getProject().getBuildDir().mkdirs();    // build dir can be not created yet
+        ProcessRunner processRunner = org.mockito.release.exec.Exec.getProcessRunner(getProject().getBuildDir());
+        processRunner.run("git", "clone", repository, targetDir.getAbsolutePath());
+    }
+
+    @Input
+    public void setRepository(String repository) {
+        this.repository = repository;
+    }
+
+    @OutputDirectory
+    public void setTargetDir(File targetDir) {
+        this.targetDir = targetDir;
+    }
+
+    public File getTargetDir() {
+        return targetDir;
+    }
+}

--- a/src/main/groovy/org/mockito/release/internal/gradle/CloneGitRepositoryTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/CloneGitRepositoryTask.java
@@ -29,6 +29,11 @@ public class CloneGitRepositoryTask extends DefaultTask {
         processRunner.run("git", "clone", repository, targetDir.getAbsolutePath());
     }
 
+    //TODO ms - let's put javadoc on all public methods of the task
+    // No need to put it on "cloneRepository" method because it is not intended to be used by end users.
+    // It's nice if javadoc for 'repository' demonstrates an example value
+    // When reading the API by looking at method signature
+    //   I don't know if repository should be a name of repo or valid url to the repo
     @Input
     public void setRepository(String repository) {
         this.repository = repository;

--- a/src/main/groovy/org/mockito/release/internal/gradle/E2ETestingPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/E2ETestingPlugin.java
@@ -6,9 +6,10 @@ import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.*;
+import org.mockito.release.exec.*;
 
 import java.io.File;
-import java.util.Collection;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 
@@ -36,24 +37,29 @@ public class E2ETestingPlugin implements Plugin<Project> {
 
         void create(String gitHubRepoUrl) {
             String repoName = extractRepoName(gitHubRepoUrl);
-            CloneGitHubRepositoryTask clone = project.getTasks().create("cloneProject" + repoName, CloneGitHubRepositoryTask.class);
+            CloneGitHubRepositoryTask clone = project.getTasks().create("cloneProjectFromGitHub" + repoName, CloneGitHubRepositoryTask.class);
             clone.setRepository(gitHubRepoUrl);
             clone.setTargetDir(new File(project.getBuildDir(), repoName + "-pristine"));
+            // For now for easier testing
+            clone.dependsOn("clean");
 
-            //TODO MS git clone from -pristine instead of copy?
+            // Clone from *-pristine to *-work. Copy task will not work because of ignoring git specific files:
+            // https://discuss.gradle.org/t/copy-git-specific-files/11970
             File workDir = new File(project.getBuildDir(), repoName + "-work");
-            Copy copy = project.getTasks().create("copyProject" + repoName, Copy.class);
+            CloneGitHubRepositoryTask copy = project.getTasks().create("cloneProjectToWorkDir" + repoName, CloneGitHubRepositoryTask.class);
             copy.dependsOn(clone);
-            copy.from(clone.getTargetDir());
-            copy.into(workDir);
+            copy.setRepository(clone.getTargetDir().getAbsolutePath());
+            copy.setTargetDir(workDir);
 
             RunTestTask run = project.getTasks().create("runTest" + repoName, RunTestTask.class);
             run.dependsOn(copy);
             run.setWorkDir(workDir);
+            run.setRepoName(repoName);
+
             //Using Gradle's composite builds ("--include-build") so that we're picking up current version of tools
             run.setCommand(asList("./gradlew", "publishToMavenLocal", "testRelease",
                     "-x", "gitPush", "-x", "bintrayUpload",
-                    "--include-build", project.getRootDir().getAbsolutePath()));
+                    "--include-build", project.getRootDir().getAbsolutePath(), "-s"));
 
             //we should put the build log in separate file instead of including it in the console of the parent build
             //otherwise the output will be really messy
@@ -66,23 +72,25 @@ public class E2ETestingPlugin implements Plugin<Project> {
         }
     }
 
-    public static class CloneGitHubRepositoryTask extends Exec {
+    public static class CloneGitHubRepositoryTask extends DefaultTask {
 
-        @Input private String repository;
-        @OutputDirectory private File targetDir;
+        private String repository;
+        private File targetDir;
 
         @TaskAction
         public void cloneRepository() {
-            LOG.lifecycle("  CloneGitHubRepositoryTask cloneRepository");
-            workingDir("$projectDir");
-            commandLine("git", "clone", repository, targetDir);
-            exec();
+            LOG.lifecycle("  Clone repository");
+            getProject().getBuildDir().mkdirs();    // build dir can be not created yet
+            ProcessRunner processRunner = org.mockito.release.exec.Exec.getProcessRunner(getProject().getBuildDir());
+            processRunner.run("git", "clone", repository, targetDir.getAbsolutePath());
         }
 
+        @Input
         public void setRepository(String repository) {
             this.repository = repository;
         }
 
+        @OutputDirectory
         public void setTargetDir(File targetDir) {
             this.targetDir = targetDir;
         }
@@ -95,19 +103,37 @@ public class E2ETestingPlugin implements Plugin<Project> {
 
     public static class RunTestTask extends DefaultTask {
 
-        private Collection<String> command;
+        private List<String> command;
+        private File buildOutput;
+        private File workDir;
+        private String repoName;
 
-        public void setWorkDir(File workDir) {
-
+        @TaskAction
+        public void runTest() {
+            LOG.lifecycle("  Run test of {}. The output will be save in {}", repoName, buildOutput.getAbsoluteFile());
+            ProcessRunner processRunner = org.mockito.release.exec.Exec.getProcessRunner(workDir, buildOutput);
+            processRunner.run(command);
         }
 
         @Input
-        public void setCommand(Collection<String> command) {
+        public void setWorkDir(File workDir) {
+            this.workDir = workDir;
+        }
+
+        @Input
+        public void setCommand(List<String> command) {
             this.command = command;
         }
 
+        @OutputFile
         public void setBuildOutputFile(File file) {
-
+            buildOutput = file;
         }
+
+        @Input
+        public void setRepoName(String repoName) {
+            this.repoName = repoName;
+        }
+
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/E2ETestingPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/E2ETestingPlugin.java
@@ -28,6 +28,8 @@ public class E2ETestingPlugin implements Plugin<Project> {
         e2eTest.create("https://github.com/mockito/mockito-release-tools-example");
     }
 
+    //TODO ms - closer to the finish line we need to make this type public in one of the public packages
+    //this is how users will interface with configuring e2e tests
     public static class E2ETest {
 
         Project project;

--- a/src/main/groovy/org/mockito/release/internal/gradle/E2ETestingPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/E2ETestingPlugin.java
@@ -1,0 +1,113 @@
+package org.mockito.release.internal.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.*;
+
+import java.io.File;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+
+/**
+ * This plugin tests your library end-to-end (e2e) using client projects.
+ * TODO MS doc
+ */
+public class E2ETestingPlugin implements Plugin<Project> {
+
+    private static final Logger LOG = Logging.getLogger(ContinuousDeliveryPlugin.class);
+
+    public void apply(final Project project) {
+        E2ETest e2eTest = project.getExtensions().create("e2eTest", E2ETest.class, project);
+        // TODO hardcoded for now
+        e2eTest.create("https://github.com/mockito/mockito-release-tools-example");
+    }
+
+    public static class E2ETest {
+
+        Project project;
+
+        public E2ETest(Project project) {
+            this.project = project;
+        }
+
+        void create(String gitHubRepoUrl) {
+            String repoName = extractRepoName(gitHubRepoUrl);
+            CloneGitHubRepositoryTask clone = project.getTasks().create("cloneProject" + repoName, CloneGitHubRepositoryTask.class);
+            clone.setRepository(gitHubRepoUrl);
+            clone.setTargetDir(new File(project.getBuildDir(), repoName + "-pristine"));
+
+            //TODO MS git clone from -pristine instead of copy?
+            File workDir = new File(project.getBuildDir(), repoName + "-work");
+            Copy copy = project.getTasks().create("copyProject" + repoName, Copy.class);
+            copy.dependsOn(clone);
+            copy.from(clone.getTargetDir());
+            copy.into(workDir);
+
+            RunTestTask run = project.getTasks().create("runTest" + repoName, RunTestTask.class);
+            run.dependsOn(copy);
+            run.setWorkDir(workDir);
+            //Using Gradle's composite builds ("--include-build") so that we're picking up current version of tools
+            run.setCommand(asList("./gradlew", "publishToMavenLocal", "testRelease",
+                    "-x", "gitPush", "-x", "bintrayUpload",
+                    "--include-build", project.getRootDir().getAbsolutePath()));
+
+            //we should put the build log in separate file instead of including it in the console of the parent build
+            //otherwise the output will be really messy
+            run.setBuildOutputFile(new File(project.getBuildDir(), repoName + "-build.log"));
+        }
+
+        // TODO MS Unit testing
+        private String extractRepoName(String gitHubRepo) {
+            return gitHubRepo.substring(gitHubRepo.lastIndexOf('/') + 1, gitHubRepo.length());
+        }
+    }
+
+    public static class CloneGitHubRepositoryTask extends Exec {
+
+        @Input private String repository;
+        @OutputDirectory private File targetDir;
+
+        @TaskAction
+        public void cloneRepository() {
+            LOG.lifecycle("  CloneGitHubRepositoryTask cloneRepository");
+            workingDir("$projectDir");
+            commandLine("git", "clone", repository, targetDir);
+            exec();
+        }
+
+        public void setRepository(String repository) {
+            this.repository = repository;
+        }
+
+        public void setTargetDir(File targetDir) {
+            this.targetDir = targetDir;
+        }
+
+        public File getTargetDir() {
+            return targetDir;
+        }
+    }
+
+
+    public static class RunTestTask extends DefaultTask {
+
+        private Collection<String> command;
+
+        public void setWorkDir(File workDir) {
+
+        }
+
+        @Input
+        public void setCommand(Collection<String> command) {
+            this.command = command;
+        }
+
+        public void setBuildOutputFile(File file) {
+
+        }
+    }
+}

--- a/src/main/groovy/org/mockito/release/internal/gradle/RunTestReleaseTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/RunTestReleaseTask.java
@@ -1,0 +1,53 @@
+package org.mockito.release.internal.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.mockito.release.exec.ProcessRunner;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * This task run external process and additionally store output of external process to file.
+ */
+public class RunTestReleaseTask extends DefaultTask {
+
+    private static final Logger LOG = Logging.getLogger(RunTestReleaseTask.class);
+
+    private List<String> command;
+    private File buildOutput;
+    private File workDir;
+    private String repoName;
+
+    @TaskAction
+    public void runTest() {
+        LOG.lifecycle("  Run test of {}. The output will be save in {}", repoName, buildOutput.getAbsoluteFile());
+        ProcessRunner processRunner = org.mockito.release.exec.Exec.getProcessRunner(workDir, buildOutput);
+        processRunner.run(command);
+    }
+
+    @Input
+    public void setWorkDir(File workDir) {
+        this.workDir = workDir;
+    }
+
+    @Input
+    public void setCommand(List<String> command) {
+        this.command = command;
+    }
+
+    @Input
+    public void setRepoName(String repoName) {
+        this.repoName = repoName;
+    }
+
+    @OutputFile
+    public void setBuildOutputFile(File file) {
+        buildOutput = file;
+    }
+
+}

--- a/src/main/resources/META-INF/gradle-plugins/org.mockito.mockito-release-tools.e2e-test.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.mockito.mockito-release-tools.e2e-test.properties
@@ -1,0 +1,1 @@
+implementation-class=org.mockito.release.internal.gradle.E2ETestingPlugin

--- a/src/test/groovy/org/mockito/release/internal/gradle/E2ETestingPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/E2ETestingPluginTest.groovy
@@ -7,14 +7,35 @@ class E2ETestingPluginTest extends Specification {
 
     def project = new ProjectBuilder().build()
 
-    def "e2e"() {
+    def "e2e with example project by default"() {
         project.plugins.apply("org.mockito.mockito-release-tools.e2e-test")
         println project.tasks
 
-//        when:
-//        project.e2eTest.create("https://github.com/mockito/mockito-release-tools-example")
-
         expect:
-        project.tasks.'runTestmockito-release-tools-example'
+        project.tasks.'runTestMockito-release-tools-example'
+    }
+
+    def "should extract project name correctly"() {
+        E2ETestingPlugin.E2ETest sut = new E2ETestingPlugin.E2ETest(project)
+
+        when:
+        sut.create("https://github.com/mockito/mockito")
+
+        then:
+        project.tasks.runTestMockito
+        project.tasks.cloneProjectFromGitHubMockito
+        project.tasks.cloneProjectToWorkDirMockito
+    }
+
+    def "should extract project name correctly when slash is the last char in url"() {
+        E2ETestingPlugin.E2ETest sut = new E2ETestingPlugin.E2ETest(project)
+
+        when:
+        sut.create("https://github.com/xx/yyy/")
+
+        then:
+        project.tasks.runTestYyy
+        project.tasks.cloneProjectFromGitHubYyy
+        project.tasks.cloneProjectToWorkDirYyy
     }
 }

--- a/src/test/groovy/org/mockito/release/internal/gradle/E2ETestingPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/E2ETestingPluginTest.groovy
@@ -9,10 +9,9 @@ class E2ETestingPluginTest extends Specification {
 
     def "e2e with example project by default"() {
         project.plugins.apply("org.mockito.mockito-release-tools.e2e-test")
-        println project.tasks
 
         expect:
-        project.tasks.'runTestMockito-release-tools-example'
+        project.tasks.'runTestReleaseMockito-release-tools-example'
     }
 
     def "should extract project name correctly"() {
@@ -22,7 +21,7 @@ class E2ETestingPluginTest extends Specification {
         sut.create("https://github.com/mockito/mockito")
 
         then:
-        project.tasks.runTestMockito
+        project.tasks.runTestReleaseMockito
         project.tasks.cloneProjectFromGitHubMockito
         project.tasks.cloneProjectToWorkDirMockito
     }
@@ -34,7 +33,7 @@ class E2ETestingPluginTest extends Specification {
         sut.create("https://github.com/xx/yyy/")
 
         then:
-        project.tasks.runTestYyy
+        project.tasks.runTestReleaseYyy
         project.tasks.cloneProjectFromGitHubYyy
         project.tasks.cloneProjectToWorkDirYyy
     }

--- a/src/test/groovy/org/mockito/release/internal/gradle/E2ETestingPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/E2ETestingPluginTest.groovy
@@ -1,0 +1,20 @@
+package org.mockito.release.internal.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class E2ETestingPluginTest extends Specification {
+
+    def project = new ProjectBuilder().build()
+
+    def "e2e"() {
+        project.plugins.apply("org.mockito.mockito-release-tools.e2e-test")
+        println project.tasks
+
+//        when:
+//        project.e2eTest.create("https://github.com/mockito/mockito-release-tools-example")
+
+        expect:
+        project.tasks.'runTestmockito-release-tools-example'
+    }
+}


### PR DESCRIPTION
This PR can: 
* clone mockit-release-tools-example
* change used version of mockito-release-tools used in mockit-release-tools-example project to current
* run `./gradlew performRelease -Preleasing.dryRun` 
The problem is, that this command doesn't work well on local environment, where GitHub write access token for mockit-release-tools-example is not provided. I started to workaround this problem, but it adds a lot of complexity to tools - see changes in: https://github.com/mockito/mockito-release-tools/pull/127