### PR TITLE
Adding gradle-plugin-releasing to the deps and ciPrepareRelease to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
   - ./gradlew build -s -i
 
 after_success:
-  - ./gradlew travisRelease -s
+  - ./gradlew ciReleasePrepare && ./gradlew travisRelease bumpVersionAndPush -s

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
-        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.8.10"
+        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.8.13"
     }
 }
 
@@ -15,7 +15,7 @@ apply plugin: 'groovy'
 apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'checkstyle'
 apply plugin: 'codenarc'
-apply plugin: 'org.mockito.release-tools.auto-versioning'
+apply plugin: 'org.mockito.mockito-release-tools.gradle-plugin-releasing'
 
 apply from: 'gradle/precommit.gradle'
 apply from: 'gradle/release.gradle'
@@ -94,7 +94,7 @@ task travisRelease {
     doLast {
         logger.lifecycle("{} - Publishing to Gradle Plugin Portal...", path)
         exec {
-            commandLine "./gradlew", "publishPlugins", "bumpVersionAndPush",
+            commandLine "./gradlew", "publishPlugins",
                     "-Pgradle.publish.key=${System.getenv('GRADLE_PUBLISH_KEY')}",
                     "-Pgradle.publish.secret=${System.getenv('GRADLE_PUBLISH_SECRET')}"
         }


### PR DESCRIPTION
Added dependency on gradle-plugin-releasing plugin so that ciPrepareRelease can be used in the project. We need it for Travis build, to prepare environment before automated version bump and push.