### PR TITLE
BumpVersionAndPush temporarily run in dryMode until 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
   - ./gradlew build -s -i
 
 after_success:
-  - ./gradlew ciReleasePrepare && ./gradlew travisRelease bumpVersionAndPush -s -Preleasing.dryRun=false
+  - ./gradlew ciReleasePrepare && ./gradlew travisRelease -s

--- a/build.gradle
+++ b/build.gradle
@@ -88,13 +88,14 @@ task releaseNeeded {
     }
 }
 
+//TODO ww add -Preleasing.dryRun=false to commandLine when releaseNeeded takes into account [ci skipRelease] in commit msg
 task travisRelease {
     dependsOn releaseNeeded
     onlyIf { releaseNeeded.needed }
     doLast {
         logger.lifecycle("{} - Publishing to Gradle Plugin Portal...", path)
         exec {
-            commandLine "./gradlew", "publishPlugins",
+            commandLine "./gradlew", "publishPlugins bumpVersionAndPush",
                     "-Pgradle.publish.key=${System.getenv('GRADLE_PUBLISH_KEY')}",
                     "-Pgradle.publish.secret=${System.getenv('GRADLE_PUBLISH_SECRET')}"
         }

--- a/version.properties
+++ b/version.properties
@@ -1,6 +1,6 @@
 #Version of the produced binaries. This file is intended to be checked-in.
 #It will be automatically bumped by release automation.
-version=0.8.20
+version=0.8.21
 
 #Last previous release version
-previousVersion=0.8.19
+previousVersion=0.8.20


### PR DESCRIPTION
releaseNeeded takes into account "ci skipRelease" in commit msg #84