### PR TITLE
AllContributorsSerializer changed to get and return JSON String

### DIFF
--- a/src/main/groovy/org/mockito/release/gradle/IncrementalReleaseNotes.java
+++ b/src/main/groovy/org/mockito/release/gradle/IncrementalReleaseNotes.java
@@ -12,6 +12,7 @@ import org.mockito.release.notes.contributors.ProjectContributorsSet;
 import org.mockito.release.notes.format.ReleaseNotesFormatters;
 import org.mockito.release.notes.model.Contribution;
 import org.mockito.release.notes.model.ReleaseNotesData;
+import org.mockito.release.notes.util.IOUtil;
 
 import java.io.File;
 import java.util.Collection;
@@ -169,7 +170,7 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
         String tagPrefix = "v";
 
         Collection<ReleaseNotesData> data = new ReleaseNotesSerializer(releaseNotesData).deserialize();
-        ProjectContributorsSet contributors = Contributors.getAllContributorsSerializer(contributorsData).deserialize();
+        ProjectContributorsSet contributors = Contributors.getAllContributorsSerializer().deserialize(IOUtil.readFully(contributorsData));
         //TODO this is not nice at all. Suggested plan:
         // Merge the functionality of recent contributors fetching + all contributors fetching.
         // 1. Make the the release notes fetcher depend on the contributors fetcher

--- a/src/main/groovy/org/mockito/release/gradle/contributors/ConfigureContributorsTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/contributors/ConfigureContributorsTask.java
@@ -9,6 +9,7 @@ import org.mockito.release.gradle.ReleaseConfiguration;
 import org.mockito.release.notes.contributors.AllContributorsSerializer;
 import org.mockito.release.notes.contributors.ProjectContributorsSet;
 import org.mockito.release.notes.model.ProjectContributor;
+import org.mockito.release.notes.util.IOUtil;
 
 import java.io.File;
 import java.util.LinkedList;
@@ -57,7 +58,7 @@ public class ConfigureContributorsTask extends DefaultTask {
     }
 
     @TaskAction public void configure() {
-        ProjectContributorsSet all = new AllContributorsSerializer(contributorsData).deserialize();
+        ProjectContributorsSet all = new AllContributorsSerializer().deserialize(IOUtil.readFully(contributorsData));
         List<String> contributors = new LinkedList<String>();
         for (ProjectContributor c : all.getAllContributors()) {
             contributors.add(c.getLogin() + ":" + (isEmpty(c.getName())? c.getLogin() : c.getName()));

--- a/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/AllContributorsFetcherTask.java
@@ -11,6 +11,7 @@ import org.mockito.release.notes.contributors.AllContributorsSerializer;
 import org.mockito.release.notes.contributors.Contributors;
 import org.mockito.release.notes.contributors.GitHubContributorsProvider;
 import org.mockito.release.notes.contributors.ProjectContributorsSet;
+import org.mockito.release.notes.util.IOUtil;
 
 import java.io.File;
 
@@ -78,8 +79,9 @@ public class AllContributorsFetcherTask extends DefaultTask {
         GitHubContributorsProvider contributorsProvider = Contributors.getGitHubContributorsProvider(repository, readOnlyAuthToken);
         ProjectContributorsSet contributors = contributorsProvider.getAllContributorsForProject();
 
-        AllContributorsSerializer serializer = Contributors.getAllContributorsSerializer(outputFile);
-        serializer.serialize(contributors);
+        AllContributorsSerializer serializer = Contributors.getAllContributorsSerializer();
+        final String json = serializer.serialize(contributors);
+        IOUtil.writeFile(outputFile, json);
 
         LOG.lifecycle("  Serialized all contributors into: {}", getProject().relativePath(outputFile));
     }

--- a/src/main/groovy/org/mockito/release/notes/contributors/AllContributorsSerializer.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/AllContributorsSerializer.java
@@ -6,33 +6,23 @@ import org.json.simple.JsonArray;
 import org.json.simple.JsonObject;
 import org.json.simple.Jsoner;
 import org.mockito.release.notes.model.ProjectContributor;
-import org.mockito.release.notes.util.IOUtil;
 
-import java.io.File;
 import java.util.Collection;
 
 public class AllContributorsSerializer {
 
     private static final Logger LOG = Logging.getLogger(AllContributorsSerializer.class);
 
-    private final File file;
-
-    public AllContributorsSerializer(File file) {
-        this.file = file;
-    }
-
-    public void serialize(ProjectContributorsSet contributorsSet) {
+    public String serialize(ProjectContributorsSet contributorsSet) {
         Collection<ProjectContributor> allContributors = contributorsSet.getAllContributors();
         String json = Jsoner.serialize(allContributors);
         LOG.info("Serialize contributors to: {}", json);
-        IOUtil.writeFile(file, json);
+        return json;
     }
 
-    public ProjectContributorsSet deserialize() {
-        String json = "";
+    public ProjectContributorsSet deserialize(String json) {
         ProjectContributorsSet set = new DefaultProjectContributorsSet();
         try {
-            json = IOUtil.readFully(file);
             LOG.info("Deserialize project contributors from: {}", json);
             JsonArray array = (JsonArray) Jsoner.deserialize(json);
             for (Object object : array) {

--- a/src/main/groovy/org/mockito/release/notes/contributors/Contributors.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/Contributors.java
@@ -28,11 +28,10 @@ public class Contributors {
 
     /**
      * Return Json serializer for all project contributors
-     * @param contributorsFile file where all project contributions are stored
      * @return instance of {@link AllContributorsSerializer}
      */
-    public static AllContributorsSerializer getAllContributorsSerializer(File contributorsFile) {
-        return new AllContributorsSerializer(contributorsFile);
+    public static AllContributorsSerializer getAllContributorsSerializer() {
+        return new AllContributorsSerializer();
     }
 
 }

--- a/src/main/groovy/org/mockito/release/notes/contributors/DefaultAllProjectContributorsReader.java
+++ b/src/main/groovy/org/mockito/release/notes/contributors/DefaultAllProjectContributorsReader.java
@@ -1,12 +1,16 @@
 package org.mockito.release.notes.contributors;
 
+import org.mockito.release.notes.util.IOUtil;
+
 import java.io.File;
 
 public class DefaultAllProjectContributorsReader implements AllProjectContributorsReader {
 
     @Override
     public ProjectContributorsSet loadAllContributors(String filePath) {
-        return new AllContributorsSerializer(new File(filePath)).deserialize();
+        final File file = new File(filePath);
+        final String fileContent = IOUtil.readFully(file);
+        return new AllContributorsSerializer().deserialize(fileContent);
     }
 
 }

--- a/src/test/groovy/org/mockito/release/notes/contributors/AllContributorsSerializerTest.groovy
+++ b/src/test/groovy/org/mockito/release/notes/contributors/AllContributorsSerializerTest.groovy
@@ -5,8 +5,7 @@ import spock.lang.Subject
 
 class AllContributorsSerializerTest extends Specification {
 
-    private File tempFile = new File(System.getProperty("java.io.tmpdir") + "/project-contributors.json")
-    @Subject serializer = new AllContributorsSerializer(tempFile)
+    @Subject serializer = new AllContributorsSerializer()
 
     def "serialization and deserialization of one contributor"() {
         def contributors = new DefaultProjectContributorsSet()
@@ -14,8 +13,8 @@ class AllContributorsSerializerTest extends Specification {
         contributors.addContributor(contributor)
 
         when:
-        serializer.serialize(contributors)
-        def actual = serializer.deserialize()
+        def serializeData = serializer.serialize(contributors)
+        def actual = serializer.deserialize(serializeData)
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -26,8 +25,8 @@ class AllContributorsSerializerTest extends Specification {
         def contributors = new DefaultProjectContributorsSet()
 
         when:
-        serializer.serialize(contributors)
-        def actual = serializer.deserialize()
+        def serializedData = serializer.serialize(contributors)
+        def actual = serializer.deserialize(serializedData)
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -43,8 +42,8 @@ class AllContributorsSerializerTest extends Specification {
         contributors.addContributor(contributor2)
 
         when:
-        serializer.serialize(contributors)
-        def actual = serializer.deserialize()
+        def serializedData = serializer.serialize(contributors)
+        def actual = serializer.deserialize(serializedData)
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -57,8 +56,8 @@ class AllContributorsSerializerTest extends Specification {
         contributors.addContributor(contributor)
 
         when:
-        serializer.serialize(contributors)
-        def actual = serializer.deserialize()
+        def serializedData = serializer.serialize(contributors)
+        def actual = serializer.deserialize(serializedData)
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -71,8 +70,8 @@ class AllContributorsSerializerTest extends Specification {
         contributors.addContributor(contributor)
 
         when:
-        serializer.serialize(contributors)
-        def actual = serializer.deserialize()
+        def serializedData = serializer.serialize(contributors)
+        def actual = serializer.deserialize(serializedData)
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())
@@ -85,8 +84,8 @@ class AllContributorsSerializerTest extends Specification {
         contributors.addContributor(contributor)
 
         when:
-        serializer.serialize(contributors)
-        def actual = serializer.deserialize()
+        def serializedData = serializer.serialize(contributors)
+        def actual = serializer.deserialize(serializedData)
 
         then:
         actual.getAllContributors().containsAll(contributors.getAllContributors())


### PR DESCRIPTION
Please give me feedback if this is correct way. I can continue with this to close #91 but as I wrote in this issue, I think that serializers should only do one job, serialize to JSON without writing data to file. This can give us more flexibility to reuse serializers in other serializers.
Cheers!