### PR TITLE
Fixed the problem with incorrect handling of branch

### DIFF
--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -36,6 +36,7 @@ public class ReleaseConfiguration {
         git.setReleasableBranchRegex("master|release/.+");  // matches 'master', 'release/2.x', 'release/3.x', etc.
         team.setContributors(Collections.<String>emptyList());
         team.setDevelopers(Collections.<String>emptyList());
+        git.setCommitMessagePostfix("[ci skip]");
     }
 
     //TODO currently it's not clear when to use class fields and when to use the 'configuration' map

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -26,7 +26,6 @@ public class ReleaseConfiguration {
     private final ReleaseNotes releaseNotes = new ReleaseNotes();
     private final Git git = new Git();
     private final Team team = new Team();
-    private final Build build = new Build();
 
     private boolean notableRelease;
     private String previousReleaseVersion;
@@ -103,51 +102,6 @@ public class ReleaseConfiguration {
      */
     public String getPreviousReleaseVersion() {
         return previousReleaseVersion;
-    }
-
-    /**
-     * Settings of the current build job.
-     * Typically they are inferred from env variables
-     */
-    public Build getBuild() {
-        return build;
-    }
-
-    /**
-     * Settings for the current build job.
-     */
-    public class Build {
-
-        private String commitMessage;
-        private boolean pullRequest;
-
-        /**
-         * Commit message of the commit that triggered the job
-         */
-        public String getCommitMessage() {
-            return commitMessage;
-        }
-
-        /**
-         * See {@link #getCommitMessage()}
-         */
-        public void setCommitMessage(String commitMessage) {
-            this.commitMessage = commitMessage;
-        }
-
-        /**
-         * Whether this Travis job is a pull request build
-         */
-        public boolean isPullRequest() {
-            return pullRequest;
-        }
-
-        /**
-         * See {@link #isPullRequest()}
-         */
-        public void setPullRequest(boolean pullRequest) {
-            this.pullRequest = pullRequest;
-        }
     }
 
     public class GitHub {

--- a/src/main/groovy/org/mockito/release/internal/gradle/GitStatusPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/GitStatusPlugin.java
@@ -3,6 +3,8 @@ package org.mockito.release.internal.gradle;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.mockito.release.exec.Exec;
 import org.mockito.release.exec.ProcessRunner;
 
@@ -13,6 +15,7 @@ import org.mockito.release.exec.ProcessRunner;
 public class GitStatusPlugin implements Plugin<Project> {
 
     private GitStatus gitStatus;
+    private final static Logger LOG = Logging.getLogger(Logger.class);
 
     @Override
     public void apply(Project project) {
@@ -52,6 +55,7 @@ public class GitStatusPlugin implements Plugin<Project> {
                 synchronized (SYNC) {
                     if (branchName == null || branchName.isEmpty()) {
                         branchName = runner.run("git", "rev-parse", "--abbrev-ref", "HEAD").trim();
+                        LOG.lifecycle("  Identified current git branch as: " + branchName);
                     }
                 }
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNeededPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNeededPlugin.java
@@ -9,7 +9,7 @@ import org.mockito.release.gradle.ReleaseNeededTask;
 import org.mockito.release.internal.comparison.PublicationsComparatorTask;
 import org.mockito.release.internal.gradle.util.TaskMaker;
 
-import static org.mockito.release.internal.gradle.configuration.LazyConfiguration.lazyConfiguration;
+import static org.mockito.release.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
 
 /**
  * Adds tasks for checking if release is needed
@@ -54,8 +54,6 @@ public class ReleaseNeededPlugin implements Plugin<Project> {
             public void execute(final ReleaseNeededTask t) {
                 t.setDescription("Asserts that criteria for the release are met and throws exception if release not needed.");
                 t.setExplosive(true);
-                t.setCommitMessage(conf.getBuild().getCommitMessage());
-                t.setPullRequest(conf.getBuild().isPullRequest());
 
                 project.allprojects(new Action<Project>() {
                     public void execute(final Project subproject) {
@@ -69,11 +67,8 @@ public class ReleaseNeededPlugin implements Plugin<Project> {
                     }
                 });
 
-                final GitStatusPlugin.GitStatus gitStatus = project.getPlugins().apply(GitStatusPlugin.class).getGitStatus();
-                lazyConfiguration(t, new Runnable() {
+                deferredConfiguration(project, new Runnable() {
                     public void run() {
-                        String branch = gitStatus.getBranch();
-                        t.setBranch(branch);
                         t.setReleasableBranchRegex(conf.getGit().getReleasableBranchRegex());
                     }
                 });

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNeededPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNeededPlugin.java
@@ -35,22 +35,24 @@ public class ReleaseNeededPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
+        final GitStatusPlugin.GitStatus gitStatus = project.getPlugins().apply(GitStatusPlugin.class).getGitStatus();
 
         //Task that throws an exception when release is not needed is very useful for CI workflows
         //Travis CI job will stop executing further commands if assertReleaseNeeded fails.
         //See the example projects how we have set up the 'assertReleaseNeeded' task in CI pipeline.
-        releaseNeededTask(project, "assertReleaseNeeded", conf)
+        releaseNeededTask(project, "assertReleaseNeeded", conf, gitStatus)
                 .setExplosive(true)
                 .setDescription("Asserts that criteria for the release are met and throws exception if release is not needed.");
 
         //Below task is useful for testing. It will not throw an exception but will run the code that check is release is needed
         //and it will print the information to the console.
-        releaseNeededTask(project, "releaseNeeded", conf)
+        releaseNeededTask(project, "releaseNeeded", conf, gitStatus)
                 .setExplosive(false)
                 .setDescription("Checks and prints to the console if criteria for the release are met.");
     }
 
-    private static ReleaseNeededTask releaseNeededTask(final Project project, String taskName, final ReleaseConfiguration conf) {
+    private static ReleaseNeededTask releaseNeededTask(final Project project, String taskName,
+                                                       final ReleaseConfiguration conf, final GitStatusPlugin.GitStatus gitStatus) {
         return TaskMaker.task(project, taskName, ReleaseNeededTask.class, new Action<ReleaseNeededTask>() {
             public void execute(final ReleaseNeededTask t) {
                 t.setDescription("Asserts that criteria for the release are met and throws exception if release not needed.");
@@ -68,7 +70,6 @@ public class ReleaseNeededPlugin implements Plugin<Project> {
                     }
                 });
 
-                final GitStatusPlugin.GitStatus gitStatus = project.getPlugins().apply(GitStatusPlugin.class).getGitStatus();
                 deferredConfiguration(project, new Runnable() {
                     public void run() {
                         t.setReleasableBranchRegex(conf.getGit().getReleasableBranchRegex());

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNeededPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNeededPlugin.java
@@ -10,6 +10,7 @@ import org.mockito.release.internal.comparison.PublicationsComparatorTask;
 import org.mockito.release.internal.gradle.util.TaskMaker;
 
 import static org.mockito.release.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
+import static org.mockito.release.internal.gradle.configuration.LazyConfiguration.lazyConfiguration;
 
 /**
  * Adds tasks for checking if release is needed
@@ -67,9 +68,18 @@ public class ReleaseNeededPlugin implements Plugin<Project> {
                     }
                 });
 
+                final GitStatusPlugin.GitStatus gitStatus = project.getPlugins().apply(GitStatusPlugin.class).getGitStatus();
                 deferredConfiguration(project, new Runnable() {
                     public void run() {
                         t.setReleasableBranchRegex(conf.getGit().getReleasableBranchRegex());
+                    }
+                });
+                lazyConfiguration(t, new Runnable() {
+                    public void run() {
+                        //if the user or some other task have configured the branch, don't overwrite it
+                        if (t.getBranch() == null) {
+                            t.setBranch(gitStatus.getBranch());
+                        }
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
@@ -1,8 +1,10 @@
 package org.mockito.release.internal.gradle;
 
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.mockito.release.gradle.ReleaseConfiguration;
+import org.mockito.release.gradle.ReleaseNeededTask;
 import org.mockito.release.internal.gradle.configuration.BasicValidator;
 import org.mockito.release.internal.gradle.configuration.LazyConfiguration;
 
@@ -18,31 +20,40 @@ import static org.mockito.release.internal.gradle.GitSetupPlugin.CHECKOUT_BRANCH
 public class TravisPlugin implements Plugin<Project> {
 
     @Override
-    public void apply(Project project) {
+    public void apply(final Project project) {
         project.getPlugins().apply(GitSetupPlugin.class);
         ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
-
-        conf.getBuild().setCommitMessage(System.getenv("TRAVIS_COMMIT_MESSAGE"));
 
         String buildNo = System.getenv("TRAVIS_BUILD_NUMBER");
         if (buildNo != null) {
             conf.getGit().setCommitMessagePostfix("by Travis CI build " + buildNo + " [ci skip]");
         } else {
-            conf.getGit().setCommitMessagePostfix("[ci skip]");
+            conf.getGit().setCommitMessagePostfix("[ci skip]"); //TODO belongs to the defaults, not here
         }
 
         String pr = System.getenv("TRAVIS_PULL_REQUEST");
-        boolean isPullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
-        conf.getBuild().setPullRequest(isPullRequest);
+        final boolean isPullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
 
         final GitCheckOutTask checkout = (GitCheckOutTask) project.getTasks().getByName(CHECKOUT_BRANCH_TASK);
-        checkout.setRev(System.getenv("TRAVIS_BRANCH"));
-
+        final String branch = System.getenv("TRAVIS_BRANCH");
+        checkout.setRev(branch);
         LazyConfiguration.lazyConfiguration(checkout, new Runnable() {
             public void run() {
                 BasicValidator.notNull(checkout.getRev(),
                         "Please export 'TRAVIS_BRANCH' environment variable first!\n" +
                                 "Alternatively, configure '" + checkout.getPath() + ".rev' task property.");
+            }
+        });
+
+        project.getPlugins().withType(ReleaseNeededPlugin.class, new Action<ReleaseNeededPlugin>() {
+            public void execute(ReleaseNeededPlugin p) {
+                project.getTasks().withType(ReleaseNeededTask.class, new Action<ReleaseNeededTask>() {
+                    public void execute(ReleaseNeededTask t) {
+                        t.setBranch(branch);
+                        t.setCommitMessage(System.getenv("TRAVIS_COMMIT_MESSAGE"));
+                        t.setPullRequest(isPullRequest);
+                    }
+                });
             }
         });
     }

--- a/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/TravisPlugin.java
@@ -27,8 +27,6 @@ public class TravisPlugin implements Plugin<Project> {
         String buildNo = System.getenv("TRAVIS_BUILD_NUMBER");
         if (buildNo != null) {
             conf.getGit().setCommitMessagePostfix("by Travis CI build " + buildNo + " [ci skip]");
-        } else {
-            conf.getGit().setCommitMessagePostfix("[ci skip]"); //TODO belongs to the defaults, not here
         }
 
         String pr = System.getenv("TRAVIS_PULL_REQUEST");

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationTest.groovy
@@ -22,12 +22,6 @@ class ReleaseConfigurationTest extends Specification {
         conf.git.commitMessagePostfix ==  " by CI build 1234 [ci skip-release]"
     }
 
-    def "empty build settings are ok"() {
-        expect:
-        conf.build.commitMessage == null
-        !conf.build.pullRequest
-    }
-
     def "validates team members"() {
         when:
         conf.team.developers = []

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationTest.groovy
@@ -11,6 +11,7 @@ class ReleaseConfigurationTest extends Specification {
     def "default values"() {
         conf.team.developers.empty
         conf.team.contributors.empty
+        conf.git.commitMessagePostfix == "[ci skip]"
     }
 
     def "custom commitMessagePostfix"() {


### PR DESCRIPTION
Useful to review commit-by-commit

- Fixed the symptom of the problem is described in #143
- Refactorings and tidy-ups

Solution to #143:
- Made the TravisPlugin configure ReleaseNeededTask explicitly.
 We no longer need to use the release configuration object to pass state between tasks.
 That was really awkward.
- Simplified the configuration. The "build" part of the configuration did not make much sense.
It is not a setting the user would configure, it was for internal use of our tasks