### PR TITLE
Version bumps are now pushed to the repo

### DIFF
--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -146,6 +146,12 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
             }
         });
 
+        //commit task that is added by GitPlugin needs to run after the add bump version task added by AutoVersioningPlugin
+        //TODO: let's think about a way to avoid 'git add' tasks completely.
+        //      We can use git commit with paths to commit specific files without the need for 'add' operation
+        //      Using 'git add' adds complexity and causes weird bugs like #145
+        project.getTasks().getByName(GitPlugin.COMMIT_TASK).mustRunAfter(AutoVersioningPlugin.ADD_BUMP_VERSION_TASK);
+
         TaskMaker.task(project, "performRelease", new Action<Task>() {
             public void execute(final Task t) {
                 t.setDescription("Performs release. " +
@@ -153,7 +159,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                         "Test with: './gradlew testRelease'");
 
                 t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, "updateReleaseNotes", "updateNotableReleaseNotes");
-                t.dependsOn("gitAddBumpVersion", "gitAddReleaseNotes", GitPlugin.COMMIT_TASK, GitPlugin.TAG_TASK);
+                t.dependsOn(AutoVersioningPlugin.ADD_BUMP_VERSION_TASK, "gitAddReleaseNotes", GitPlugin.COMMIT_TASK, GitPlugin.TAG_TASK);
                 t.dependsOn(GitPlugin.PUSH_TASK);
                 t.dependsOn("bintrayUploadAll");
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/GitSetupPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/GitSetupPlugin.java
@@ -74,11 +74,6 @@ public class GitSetupPlugin implements Plugin<Project> {
         TaskMaker.task(project, CHECKOUT_BRANCH_TASK, GitCheckOutTask.class, new Action<GitCheckOutTask>() {
             public void execute(final GitCheckOutTask t) {
                 t.setDescription("Checks out the branch that can be committed. CI systems often check out revision that is not committable.");
-                lazyConfiguration(t, new Runnable() {
-                    public void run() {
-                        t.setRev(System.getenv("TRAVIS_BRANCH"));
-                    }
-                });
             }
         });
 


### PR DESCRIPTION
- Fixes issue #145 
- Ensured that version bump runs before git push task
- Removed unnecessary configuration (review commit-by-commit is useful for this PR)

Please review!