### PR TITLE
#147 Some contributor links are missing in Mockito release notes

### DIFF
--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -2,10 +2,7 @@ package org.mockito.release.gradle;
 
 import org.gradle.api.GradleException;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.mockito.release.internal.gradle.util.team.TeamParser.validateTeamMembers;
 
@@ -34,7 +31,7 @@ public class ReleaseConfiguration {
         //Configure default values
         git.setTagPrefix("v"); //so that tags are "v1.0", "v2.3.4"
         git.setReleasableBranchRegex("master|release/.+");  // matches 'master', 'release/2.x', 'release/3.x', etc.
-        team.setContributors(Collections.<String>emptyList());
+        configuration.put("team.contributors", new ArrayList<String>());    // can't use setter at this point
         team.setDevelopers(Collections.<String>emptyList());
         git.setCommitMessagePostfix("[ci skip]");
     }
@@ -346,7 +343,9 @@ public class ReleaseConfiguration {
          */
         public void setContributors(Collection<String> contributors) {
             validateTeamMembers(contributors);
-            configuration.put("team.contributors", contributors);
+            // because we share here contributors as 'global state' we need to add they to existing collection
+            Collection<String> current = getCollection("team.contributors");
+            current.addAll(contributors);
         }
     }
 

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -341,7 +341,7 @@ public class ReleaseConfiguration {
         /**
          * See {@link #getContributors()}
          */
-        public void setContributors(Collection<String> contributors) {
+        public void addAllContributors(Collection<String> contributors) {
             validateTeamMembers(contributors);
             // because we share here contributors as 'global state' we need to add they to existing collection
             Collection<String> current = getCollection("team.contributors");

--- a/src/main/groovy/org/mockito/release/gradle/contributors/ConfigureContributorsTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/contributors/ConfigureContributorsTask.java
@@ -66,6 +66,6 @@ public class ConfigureContributorsTask extends DefaultTask {
 
         LOG.lifecycle("  Configuring {} contributors into 'releasing.team.contributors' setting.",
                 contributors.size());
-        releaseConfiguration.getTeam().setContributors(contributors);
+        releaseConfiguration.getTeam().addAllContributors(contributors);
     }
 }

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationTest.groovy
@@ -31,9 +31,9 @@ class ReleaseConfigurationTest extends Specification {
         conf.team.developers = ["foo:bar"]
         conf.team.developers = ["foo:bar", "x:y"]
 
-        conf.team.contributors = []
-        conf.team.contributors = ["foo:bar"]
-        conf.team.contributors = ["foo:bar", "x:y"]
+        conf.team.addAllContributors([])
+        conf.team.addAllContributors(["foo:bar"])
+        conf.team.addAllContributors(["foo:bar", "x:y"])
 
         then:
         noExceptionThrown()
@@ -43,7 +43,7 @@ class ReleaseConfigurationTest extends Specification {
         when: conf.team.developers = [""]
         then: thrown(TeamParser.InvalidInput.class)
 
-        when: conf.team.contributors = ["ala:"]
+        when: conf.team.addAllContributors(["ala:"])
         then: thrown(TeamParser.InvalidInput.class)
     }
 
@@ -53,7 +53,7 @@ class ReleaseConfigurationTest extends Specification {
         def newContributors = asList("foo:bar", "fiz:buz")
 
         when:
-        conf.getTeam().setContributors(newContributors)
+        conf.getTeam().addAllContributors(newContributors)
 
         then:
         conf.getTeam().getContributors() == contributors    // check is the same reference

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationTest.groovy
@@ -4,6 +4,8 @@ import org.mockito.release.gradle.ReleaseConfiguration
 import org.mockito.release.internal.gradle.util.team.TeamParser
 import spock.lang.Specification
 
+import static java.util.Arrays.asList
+
 class ReleaseConfigurationTest extends Specification {
 
     def conf = new ReleaseConfiguration()
@@ -43,5 +45,18 @@ class ReleaseConfigurationTest extends Specification {
 
         when: conf.team.contributors = ["ala:"]
         then: thrown(TeamParser.InvalidInput.class)
+    }
+
+    def "contributors list should return always original reference because of global state"() {
+        given:
+        def contributors = conf.getTeam().getContributors()
+        def newContributors = asList("foo:bar", "fiz:buz")
+
+        when:
+        conf.getTeam().setContributors(newContributors)
+
+        then:
+        conf.getTeam().getContributors() == contributors    // check is the same reference
+        conf.getTeam().getContributors().containsAll(asList("foo:bar", "fiz:buz"))
     }
 }

--- a/src/test/groovy/org/mockito/release/internal/gradle/util/PomCustomizerTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/util/PomCustomizerTest.groovy
@@ -30,7 +30,7 @@ class PomCustomizerTest extends Specification {
         conf.gitHub.repository = "repo"
         conf.team.developers = ["szczepiq:Szczepan Faber", "wwilk:Wojtek Wilk"]
         //wwilk will not be duplicated in developers/contributors
-        conf.team.contributors = ["mstachniuk:Marcin Stachniuk", "wwilk:Wojtek Wilk"]
+        conf.team.addAllContributors(["mstachniuk:Marcin Stachniuk", "wwilk:Wojtek Wilk"])
 
         PomCustomizer.customizePom(node, conf, "foo", "Foo library")
 
@@ -89,7 +89,7 @@ class PomCustomizerTest extends Specification {
     def "empty team settings"() {
         conf.gitHub.repository = "repo"
         conf.team.developers = []
-        conf.team.contributors = []
+        conf.team.addAllContributors([])
 
         PomCustomizer.customizePom(node, conf, "foo", "Foo library")
 


### PR DESCRIPTION
ReleaseConfiguration().getTeam().getContributors() is used in different
places in code to define task's configuration. It needs to be always
the same reference during execution.