### PR TITLE
Improved test coverage of ReleaseNeededTask

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,3 +1,4 @@
+#!/bin/bash
 # pre-commit.sh
 # based on: https://gist.github.com/KenVanHoeylandt/c7a928426bce83ffab400ab1fd99054a
 # and on: http://codeinthehole.com/tips/tips-for-using-a-git-pre-commit-hook/

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -5,7 +5,9 @@ import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.TaskAction;
+import org.mockito.release.internal.DefaultEnvPropertyAccessor;
 import org.mockito.release.internal.comparison.PublicationsComparatorTask;
+import org.mockito.release.internal.util.EnvPropertyAccessor;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -34,6 +36,7 @@ public class ReleaseNeededTask extends DefaultTask {
     private boolean pullRequest;
     private boolean explosive;
     private boolean releaseNotNeeded;
+    private EnvPropertyAccessor envPropertyAccessor = new DefaultEnvPropertyAccessor();
 
     /**
      * The branch we currently operate on
@@ -106,8 +109,8 @@ public class ReleaseNeededTask extends DefaultTask {
         return this;
     }
 
-    @TaskAction public void releaseNeeded() {
-        boolean skipEnvVariable = System.getenv(SKIP_RELEASE_ENV) != null;
+    @TaskAction public boolean releaseNeeded() {
+        boolean skipEnvVariable = envPropertyAccessor.getenv(SKIP_RELEASE_ENV) != null;
         LOG.lifecycle("  Environment variable {} present: {}", SKIP_RELEASE_ENV, skipEnvVariable);
 
         boolean commitMessageEmpty = commitMessage == null || commitMessage.trim().isEmpty();
@@ -135,6 +138,8 @@ public class ReleaseNeededTask extends DefaultTask {
         } else {
             LOG.lifecycle(message);
         }
+
+        return !releaseNotNeeded;
     }
 
     public void addPublicationsComparator(PublicationsComparatorTask task) {
@@ -156,7 +161,7 @@ public class ReleaseNeededTask extends DefaultTask {
         return allEqual;
     }
 
-    boolean isReleaseNotNeeded(){
-        return releaseNotNeeded;
+    void setEnvPropertyAccessor(EnvPropertyAccessor envPropertyAccessor){
+        this.envPropertyAccessor = envPropertyAccessor;
     }
 }

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -121,7 +121,6 @@ public class ReleaseNeededTask extends DefaultTask {
 
         boolean allPublicationsEqual = areAllPublicationsEqual();
 
-        // add unit tests for release not needed
         releaseNotNeeded = allPublicationsEqual || skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch;
 
         String message = "  Release is needed: " + !releaseNotNeeded +

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -5,9 +5,11 @@ import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.impldep.com.google.gson.annotations.Expose;
 import org.mockito.release.internal.DefaultEnvPropertyAccessor;
 import org.mockito.release.internal.comparison.PublicationsComparatorTask;
 import org.mockito.release.internal.util.EnvPropertyAccessor;
+import org.mockito.release.internal.util.ExposedForTesting;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -147,6 +149,7 @@ public class ReleaseNeededTask extends DefaultTask {
         publicationsComparators.add(task);
     }
 
+    @ExposedForTesting
     boolean areAllPublicationsEqual() {
         if (publicationsComparators.isEmpty()) {
             return false;
@@ -161,6 +164,7 @@ public class ReleaseNeededTask extends DefaultTask {
         return allEqual;
     }
 
+    @ExposedForTesting
     void setEnvPropertyAccessor(EnvPropertyAccessor envPropertyAccessor){
         this.envPropertyAccessor = envPropertyAccessor;
     }

--- a/src/main/groovy/org/mockito/release/internal/DefaultEnvPropertyAccessor.java
+++ b/src/main/groovy/org/mockito/release/internal/DefaultEnvPropertyAccessor.java
@@ -1,0 +1,11 @@
+package org.mockito.release.internal;
+
+import org.mockito.release.internal.util.EnvPropertyAccessor;
+
+public class DefaultEnvPropertyAccessor implements EnvPropertyAccessor{
+
+    @Override
+    public String getenv(String name) {
+        return System.getenv(name);
+    }
+}

--- a/src/main/groovy/org/mockito/release/internal/util/EnvPropertyAccessor.java
+++ b/src/main/groovy/org/mockito/release/internal/util/EnvPropertyAccessor.java
@@ -1,0 +1,5 @@
+package org.mockito.release.internal.util;
+
+public interface EnvPropertyAccessor {
+    String getenv(String name);
+}

--- a/src/test/groovy/org/mockito/release/gradle/ReleaseNeededTaskTest.groovy
+++ b/src/test/groovy/org/mockito/release/gradle/ReleaseNeededTaskTest.groovy
@@ -4,11 +4,46 @@ import org.gradle.api.GradleException
 import org.gradle.testfixtures.ProjectBuilder
 import org.mockito.release.internal.comparison.PublicationsComparatorTask
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ReleaseNeededTaskTest extends Specification {
 
     def tasks = new ProjectBuilder().build().getTasks();
     ReleaseNeededTask underTest = tasks.create("releaseNeeded", ReleaseNeededTask)
+
+    @Unroll
+    def "release is needed" (commitMessage, branch, pullRequest, publicationsComparatorsResults, releaseNotNeeded){
+        given:
+        underTest.setCommitMessage(commitMessage)
+        underTest.setBranch(branch)
+        underTest.setPullRequest(pullRequest)
+        int i = 0;
+        publicationsComparatorsResults.each{
+            def task = tasks.create("" + i++, PublicationsComparatorTask)
+            task.setPublicationsEqual(it)
+            underTest.addPublicationsComparator(task)
+        }
+        underTest.setReleasableBranchRegex("master")
+
+        expect:
+        underTest.releaseNeeded()
+        
+        underTest.isReleaseNotNeeded() == releaseNotNeeded
+
+        where:
+        commitMessage       | branch    | pullRequest | publicationsComparatorsResults || releaseNotNeeded
+        "message"           | "master"  | false       | [false, false]                 || false // base case (in all other cases only one parameter changes)
+
+        null                | "master"  | false       | [false, false]                 || false // null commit msg
+        " "                 | "master"  | false       | [false, false]                 || false // only whitespaces in commit msg
+        "message"           | "master"  | false       | [true, false]                  || false  // not all publications equal
+
+        "[ci skip-release]" | "master"  | false       | [false, false]                 || true  // skip-release in commit msg
+        "message"           | "feature" | false       | [false, false]                 || true  // feature branch
+        "message"           | null      | false       | [false, false]                 || true  // null branch
+        "message"           | "master"  | true        | [false, false]                 || true  // pull request
+        "message"           | "master"  | false       | [true, true]                   || true  // all publications equal
+    }
 
     def "allPublicationsEqual should be false if no PublicationComparisonTasks"() {
         when:

--- a/src/test/groovy/org/mockito/release/gradle/ReleaseNeededTaskTest.groovy
+++ b/src/test/groovy/org/mockito/release/gradle/ReleaseNeededTaskTest.groovy
@@ -3,6 +3,7 @@ package org.mockito.release.gradle
 import org.gradle.api.GradleException
 import org.gradle.testfixtures.ProjectBuilder
 import org.mockito.release.internal.comparison.PublicationsComparatorTask
+import org.mockito.release.internal.util.EnvPropertyAccessor
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -12,11 +13,14 @@ class ReleaseNeededTaskTest extends Specification {
     ReleaseNeededTask underTest = tasks.create("releaseNeeded", ReleaseNeededTask)
 
     @Unroll
-    def "release is needed" (commitMessage, branch, pullRequest, publicationsComparatorsResults, releaseNotNeeded){
+    def "release is needed" (commitMessage, branch, pullRequest, skipEnvVar, publicationsComparatorsResults, releaseNeeded){
         given:
         underTest.setCommitMessage(commitMessage)
         underTest.setBranch(branch)
         underTest.setPullRequest(pullRequest)
+        def envPropertyAcceccor = Mock(EnvPropertyAccessor)
+        envPropertyAcceccor.getenv("SKIP_RELEASE") >> skipEnvVar
+        underTest.setEnvPropertyAccessor(envPropertyAcceccor)
         int i = 0;
         publicationsComparatorsResults.each{
             def task = tasks.create("" + i++, PublicationsComparatorTask)
@@ -26,23 +30,22 @@ class ReleaseNeededTaskTest extends Specification {
         underTest.setReleasableBranchRegex("master")
 
         expect:
-        underTest.releaseNeeded()
-        
-        underTest.isReleaseNotNeeded() == releaseNotNeeded
+        underTest.releaseNeeded() == releaseNeeded
 
         where:
-        commitMessage       | branch    | pullRequest | publicationsComparatorsResults || releaseNotNeeded
-        "message"           | "master"  | false       | [false, false]                 || false // base case (in all other cases only one parameter changes)
+        commitMessage       | branch    | pullRequest |skipEnvVar | publicationsComparatorsResults || releaseNeeded
+        "message"           | "master"  | false       | null      | [false, false]                 || true  // base case (in all other cases only one parameter changes)
 
-        null                | "master"  | false       | [false, false]                 || false // null commit msg
-        " "                 | "master"  | false       | [false, false]                 || false // only whitespaces in commit msg
-        "message"           | "master"  | false       | [true, false]                  || false  // not all publications equal
+        null                | "master"  | false       | null      | [false, false]                 || true  // null commit msg
+        " "                 | "master"  | false       | null      | [false, false]                 || true  // only whitespaces in commit msg
+        "message"           | "master"  | false       | null      | [true, false]                  || true  // not all publications equal
 
-        "[ci skip-release]" | "master"  | false       | [false, false]                 || true  // skip-release in commit msg
-        "message"           | "feature" | false       | [false, false]                 || true  // feature branch
-        "message"           | null      | false       | [false, false]                 || true  // null branch
-        "message"           | "master"  | true        | [false, false]                 || true  // pull request
-        "message"           | "master"  | false       | [true, true]                   || true  // all publications equal
+        "[ci skip-release]" | "master"  | false       | null      | [false, false]                 || false // skip-release in commit msg
+        "message"           | "feature" | false       | null      | [false, false]                 || false // feature branch
+        "message"           | null      | false       | null      | [false, false]                 || false // null branch
+        "message"           | "master"  | true        | null      | [false, false]                 || false // pull request
+        "message"           | "master"  | false       | "true"    | [false, false]                 || false // SKIP_RELEASE set
+        "message"           | "master"  | false       | null      | [true, true]                   || false // all publications equal
     }
 
     def "allPublicationsEqual should be false if no PublicationComparisonTasks"() {
@@ -102,10 +105,7 @@ class ReleaseNeededTaskTest extends Specification {
         underTest.setExplosive(false)
         underTest.setPullRequest(true) // pullRequest == true makes notNeeded == true
 
-        when:
-        underTest.releaseNeeded()
-
-        then:
-        underTest.isReleaseNotNeeded()
+        expect:
+        !underTest.releaseNeeded()
     }
 }


### PR DESCRIPTION
Since ReleaseNeededTask logic is a little complex already and it may grow, I thought it would be good to make it more reliable by adding unit tests for the value of releaseNotNeeded variable.

@szczepiq 
I haven't included skipEnvVariable in these tests yet, because it's an environment variable. Is there any reason why it can't be a system property? It would be easier for testing. If it has to stay env variable, there are some hacks we can use to set its value in tests. 