### PR TITLE
Removed the concept of notable release for now

### DIFF
--- a/src/main/groovy/org/mockito/release/gradle/BumpVersionFileTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/BumpVersionFileTask.java
@@ -5,7 +5,6 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.mockito.release.internal.gradle.util.StringUtil;
 import org.mockito.release.version.Version;
 import org.mockito.release.version.VersionInfo;
 
@@ -14,15 +13,12 @@ import java.io.File;
 /**
  * Increments version in specified file.
  * The file is expected to have a version property declared, for example: "version=0.0.1"
- * If {@link #setUpdateNotableVersions(boolean)} is set to true
- * then the previous version will be added to notable versions, e.g. "notableVersions=1.0.0,1.5.0,2.0.0"
  */
 public class BumpVersionFileTask extends DefaultTask {
 
     private final static Logger LOG = Logging.getLogger(BumpVersionFileTask.class);
 
     private File versionFile;
-    private boolean updateNotableVersions;
 
     /**
      * File that contains version number information, for example: "version=0.0.1"
@@ -40,36 +36,18 @@ public class BumpVersionFileTask extends DefaultTask {
     }
 
     /**
-     * Whether to update notable versions by adding previous version to notable versions list
-     */
-    public boolean getUpdateNotableVersions() {
-        return updateNotableVersions;
-    }
-
-    /**
-     * See {@link #getUpdateNotableVersions()}
-     */
-    public void setUpdateNotableVersions(boolean update) {
-        this.updateNotableVersions = update;
-    }
-
-    /**
      * See {@link BumpVersionFileTask}
      */
     @TaskAction public void bumpVersionFile() {
         VersionInfo versionInfo = Version.versionInfo(this.versionFile);
-        VersionInfo newVersion = versionInfo.bumpVersion(updateNotableVersions);
+        VersionInfo newVersion = versionInfo.bumpVersion();
         //TODO add unit test for the message.
         // We already had a bug related to printing VersionInfo toString() instead of neat string version.
         LOG.lifecycle("{} - updated version file '{}'\n" +
                 "  - new version: {}\n" +
-                "  - previous version: {}\n" +
-                "  - notable versions updated: {}\n" +
-                "  - notable versions: {}",
+                "  - previous version: {}\n",
                 getPath(), getProject().relativePath(this.versionFile),
                 newVersion.getVersion(),
-                newVersion.getPreviousVersion(),
-                updateNotableVersions,
-                StringUtil.join(versionInfo.getNotableVersions(), ", "));
+                newVersion.getPreviousVersion());
     }
 }

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -27,7 +27,6 @@ public class ReleaseConfiguration {
     private final Git git = new Git();
     private final Team team = new Team();
 
-    private boolean notableRelease;
     private String previousReleaseVersion;
 
     public ReleaseConfiguration() {
@@ -73,21 +72,6 @@ public class ReleaseConfiguration {
 
     public Team getTeam() {
         return team;
-    }
-
-    /**
-     * See {@link #isNotableRelease()}
-     */
-    public void setNotableRelease(boolean notableRelease) {
-        this.notableRelease = notableRelease;
-    }
-
-    /**
-     * Informs if the release is considered 'notable' release.
-     * See {@link org.mockito.release.version.VersionInfo#isNotableRelease()}
-     */
-    public boolean isNotableRelease() {
-        return notableRelease;
     }
 
     /**

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -36,6 +36,7 @@ public class ReleaseConfiguration {
         team.setContributors(Collections.<String>emptyList());
         team.setDevelopers(Collections.<String>emptyList());
         git.setCommitMessagePostfix("[ci skip]");
+        releaseNotes.setLabelMapping(Collections.<String, String>emptyMap());
     }
 
     //TODO currently it's not clear when to use class fields and when to use the 'configuration' map

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseConfiguration.java
@@ -191,20 +191,6 @@ public class ReleaseConfiguration {
         }
 
         /**
-         * Notable release notes file, for example "docs/notable-release-notes.md"
-         */
-        public String getNotableFile() {
-            return getString("releaseNotes.notableFile");
-        }
-
-        /**
-         * See {@link #getNotableFile()}
-         */
-        public void setNotableFile(String notableFile) {
-            configuration.put("releaseNotes.notableFile", notableFile);
-        }
-
-        /**
          * Issue tracker label mappings.
          * The mapping of issue tracker labels (for example "GitHub label") to human readable and presentable name.
          * The order of labels is important and will influence the order

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -38,7 +38,6 @@ public class ReleaseNeededTask extends DefaultTask {
     private String commitMessage;
     private boolean pullRequest;
     private boolean explosive;
-    private boolean releaseNotNeeded;
     private EnvVariables envVariables = new EnvVariables();
 
     /**
@@ -127,7 +126,7 @@ public class ReleaseNeededTask extends DefaultTask {
 
         boolean allPublicationsEqual = areAllPublicationsEqual();
 
-        releaseNotNeeded = allPublicationsEqual || skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch;
+        boolean releaseNotNeeded = allPublicationsEqual || skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch;
 
         String message = "  Release is needed: " + !releaseNotNeeded +
                 "\n    - skip by env variable: " + skipEnvVariable +

--- a/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/mockito/release/gradle/ReleaseNeededTask.java
@@ -26,6 +26,9 @@ public class ReleaseNeededTask extends DefaultTask {
 
     private final static Logger LOG = Logging.getLogger(ReleaseNeededTask.class);
 
+    //We are using environment variable instead of system property or Gradle project property here
+    //It's easier to configure Travis CI matrix builds using env variables
+    //For reference, see the ".travis.yml" of Mockito project
     private final static String SKIP_RELEASE_ENV = "SKIP_RELEASE";
     private final static String SKIP_RELEASE_KEYWORD = "[ci skip-release]";
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -75,7 +75,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
         TaskMaker.execTask(project, "gitAddReleaseNotes", new Action<Exec>() {
             public void execute(final Exec t) {
                 t.setDescription("Performs 'git add' for the release notes file");
-                t.mustRunAfter("updateReleaseNotes");
+                t.mustRunAfter(ReleaseNotesPlugin.UPDATE_NOTES_TASK);
                 project.getTasks().getByName(GitPlugin.COMMIT_TASK).mustRunAfter(t);
                 t.doFirst(new Action<Task>() {
                     public void execute(Task task) {
@@ -149,7 +149,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                         "Ship with: './gradlew performRelease -Preleasing.dryRun=false'. " +
                         "Test with: './gradlew testRelease'");
 
-                t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, "updateReleaseNotes");
+                t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, ReleaseNotesPlugin.UPDATE_NOTES_TASK);
                 t.dependsOn(AutoVersioningPlugin.ADD_BUMP_VERSION_TASK, "gitAddReleaseNotes", GitPlugin.COMMIT_TASK, GitPlugin.TAG_TASK);
                 t.dependsOn(GitPlugin.PUSH_TASK);
                 t.dependsOn("bintrayUploadAll");

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -90,7 +90,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                     public void execute(Task task) {
                         //doFirst (execution time)
                         // so that we can access user-configured properties
-                        t.commandLine("git", "add", conf.getReleaseNotes().getFile(), conf.getReleaseNotes().getNotableFile());
+                        t.commandLine("git", "add", conf.getReleaseNotes().getFile());
                     }
                 });
             }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -84,7 +84,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
         TaskMaker.execTask(project, "gitAddReleaseNotes", new Action<Exec>() {
             public void execute(final Exec t) {
                 t.setDescription("Performs 'git add' for the release notes file");
-                t.mustRunAfter("updateReleaseNotes", "updateNotableReleaseNotes");
+                t.mustRunAfter("updateReleaseNotes");
                 project.getTasks().getByName(GitPlugin.COMMIT_TASK).mustRunAfter(t);
                 t.doFirst(new Action<Task>() {
                     public void execute(Task task) {
@@ -158,7 +158,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                         "Ship with: './gradlew performRelease -Preleasing.dryRun=false'. " +
                         "Test with: './gradlew testRelease'");
 
-                t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, "updateReleaseNotes", "updateNotableReleaseNotes");
+                t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, "updateReleaseNotes");
                 t.dependsOn(AutoVersioningPlugin.ADD_BUMP_VERSION_TASK, "gitAddReleaseNotes", GitPlugin.COMMIT_TASK, GitPlugin.TAG_TASK);
                 t.dependsOn(GitPlugin.PUSH_TASK);
                 t.dependsOn("bintrayUploadAll");

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -5,14 +5,10 @@ import org.gradle.api.*;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Exec;
-import org.mockito.release.gradle.BumpVersionFileTask;
 import org.mockito.release.gradle.IncrementalReleaseNotes;
 import org.mockito.release.gradle.ReleaseConfiguration;
-import org.mockito.release.gradle.ReleaseNeededTask;
-import org.mockito.release.internal.comparison.PublicationsComparatorTask;
 import org.mockito.release.internal.gradle.util.BintrayUtil;
 import org.mockito.release.internal.gradle.util.TaskMaker;
-import org.mockito.release.version.VersionInfo;
 
 import static org.mockito.release.internal.gradle.BaseJavaLibraryPlugin.POM_TASK;
 import static org.mockito.release.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
@@ -72,15 +68,10 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
             }
         });
 
-        final boolean notableRelease = project.getExtensions().getByType(VersionInfo.class).isNotableRelease();
-
-        //TODO use constants for all task names
-        ((BumpVersionFileTask) project.getTasks().getByName(VersioningPlugin.BUMP_VERSION_FILE_TASK))
-                .setUpdateNotableVersions(notableRelease);
-
         //TODO we should have tasks from the same plugin to have the same group
         //let's have a task maker instance in a plugin that has sets the group accordingly
 
+        //TODO use constants for all task names
         TaskMaker.execTask(project, "gitAddReleaseNotes", new Action<Exec>() {
             public void execute(final Exec t) {
                 t.setDescription("Performs 'git add' for the release notes file");

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPlugin.java
@@ -12,7 +12,6 @@ import org.mockito.release.version.VersionInfo;
  * <ul>
  *     <li>Adds and preconfigures 'releasing' extension of type {@link ReleaseConfiguration}</li>
  *     <li>Configures 'releasing.dryRun' setting based on 'releasing.dryRun' Gradle project property</li>
- *     <li>Configures 'releasing.notableRelease' setting based on the version we are currently building</li>
  * </ul>
  */
 public class ReleaseConfigurationPlugin implements Plugin<Project> {
@@ -35,7 +34,6 @@ public class ReleaseConfigurationPlugin implements Plugin<Project> {
                 //e.g. releasing.gitHub.repository is also a property
             }
 
-            configuration.setNotableRelease(info.isNotableRelease());
             configuration.setPreviousReleaseVersion(info.getPreviousVersion());
         } else {
             //not root project, get extension from root project

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
@@ -11,9 +11,7 @@ import org.mockito.release.version.VersionInfo;
 
 import java.io.File;
 
-import static java.util.Collections.singletonList;
 import static org.mockito.release.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
-import static org.mockito.release.internal.gradle.configuration.LazyConfiguration.lazyConfiguration;
 
 /**
  * The plugin adds following tasks:
@@ -21,55 +19,19 @@ import static org.mockito.release.internal.gradle.configuration.LazyConfiguratio
  * <ul>
  *     <li>updateReleaseNotes - updates release notes file in place.</li>
  *     <li>previewReleaseNotes - prints incremental release notes to the console for preview.</li>
- *     <li>fetchNotableReleaseNotes - queries GitHub to get notable release notes data.</li>
- *     <li>updateNotableReleaseNotes - updates notable release notes file in place.</li>
  * </ul>
  */
 public class ReleaseNotesPlugin implements Plugin<Project> {
 
-    private static final String TEMP_SERIALIZED_NOTES_FILE = "/notableReleaseNotes.ser";
-
     public void apply(final Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
-        final GitStatusPlugin.GitStatus gitStatus = project.getPlugins().apply(GitStatusPlugin.class).getGitStatus();
         project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(ContributorsPlugin.class);
 
-        detailedReleaseNotes(project, conf);
-
-        project.getTasks().create("fetchNotableReleaseNotes", NotableReleaseNotesFetcherTask.class, new Action<NotableReleaseNotesFetcherTask>() {
-            public void execute(NotableReleaseNotesFetcherTask task) {
-                final NotesGeneration gen = task.getNotesGeneration();
-                preconfigureNotableNotes(project, gen);
-
-                lazyConfiguration(task, new Runnable() {
-                    public void run() {
-                        configureNotableNotes(project, gen, conf, gitStatus);
-                    }
-                });
-            }
-        });
-
-        project.getTasks().create("updateNotableReleaseNotes", NotableReleaseNotesGeneratorTask.class,
-                new Action<NotableReleaseNotesGeneratorTask>() {
-            public void execute(NotableReleaseNotesGeneratorTask task) {
-                final NotesGeneration gen = task.getNotesGeneration();
-                preconfigureNotableNotes(project, gen);
-
-                task.dependsOn("fetchNotableReleaseNotes");
-
-                lazyConfiguration(task, new Runnable() {
-                    public void run() {
-                        configureNotableNotes(project, gen, conf, gitStatus);
-                    }
-                });
-            }
-        });
-
-        configureNotableReleaseNotes(project);
+        releaseNotesTasks(project, conf);
     }
 
-    private static void detailedReleaseNotes(final Project project, final ReleaseConfiguration conf) {
+    private static void releaseNotesTasks(final Project project, final ReleaseConfiguration conf) {
         final ReleaseNotesFetcherTask fetcher = TaskMaker.task(project, "fetchReleaseNotes", ReleaseNotesFetcherTask.class, new Action<ReleaseNotesFetcherTask>() {
             public void execute(final ReleaseNotesFetcherTask t) {
                 t.setDescription("Fetches release notes data from Git and GitHub and serializes them to a file");
@@ -84,8 +46,6 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
                 });
             }
         });
-
-
 
         TaskMaker.task(project, "updateReleaseNotes", IncrementalReleaseNotes.UpdateTask.class, new Action<IncrementalReleaseNotes.UpdateTask>() {
             public void execute(final IncrementalReleaseNotes.UpdateTask t) {
@@ -116,46 +76,5 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
                 task.setPreviousVersion(project.getExtensions().getByType(VersionInfo.class).getPreviousVersion());
             }
         });
-    }
-
-    private static void preconfigureNotableNotes(Project project, NotesGeneration gen){
-        gen.setGitHubLabels(singletonList("noteworthy"));
-        gen.setGitWorkingDir(project.getRootDir());
-        gen.setIntroductionText("Notable release notes:\n\n");
-        gen.setOnlyPullRequests(true);
-        gen.setTagPrefix("v");
-        gen.setTemporarySerializedNotesFile(getTemporaryReleaseNotesFile(project));
-    }
-
-    private static void configureNotableNotes(Project project, NotesGeneration gen, ReleaseConfiguration conf, GitStatusPlugin.GitStatus gitStatus) {
-        gen.setGitHubReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
-        gen.setGitHubRepository(conf.getGitHub().getRepository());
-        gen.setOutputFile(project.file(conf.getReleaseNotes().getNotableFile()));
-        gen.setVcsCommitsLinkTemplate("https://github.com/" + conf.getGitHub().getRepository() + "/compare/{0}...{1}");
-        gen.setDetailedReleaseNotesLink(conf.getGitHub().getRepository() + "/blob/" + gitStatus.getBranch() + "/" + conf.getReleaseNotes().getNotableFile());
-    }
-
-    private static File getTemporaryReleaseNotesFile(Project project){
-        String path = project.getBuildDir()  + TEMP_SERIALIZED_NOTES_FILE;
-        return project.file(path);
-    }
-
-
-    private static void configureNotableReleaseNotes(Project project) {
-        //TODO when we make notable release notes optional, we can push that to a separate plugin
-        //like notable-release-notes plugin or something like that
-        //this way, the normal detailed release notes do not depend on versioning plugin
-        //and our plugins are more flexible
-        VersionInfo versionInfo = project.getExtensions().getByType(VersionInfo.class);
-        NotableReleaseNotesGeneratorTask generatorTask = (NotableReleaseNotesGeneratorTask) project.getTasks().getByName("updateNotableReleaseNotes");
-        NotableReleaseNotesFetcherTask fetcherTask = (NotableReleaseNotesFetcherTask) project.getTasks().getByName("fetchNotableReleaseNotes");
-
-        generatorTask.getNotesGeneration().setTargetVersions(versionInfo.getNotableVersions());
-        fetcherTask.getNotesGeneration().setTargetVersions(versionInfo.getNotableVersions());
-
-        if (versionInfo.isNotableRelease()) {
-            generatorTask.getNotesGeneration().setHeadVersion(project.getVersion().toString());
-            fetcherTask.getNotesGeneration().setHeadVersion(project.getVersion().toString());
-        }
     }
 }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
@@ -25,6 +25,10 @@ import static org.mockito.release.internal.gradle.configuration.DeferredConfigur
  */
 public class ReleaseNotesPlugin implements Plugin<Project> {
 
+    private static final String FETCH_NOTES_TASK = "fetchReleaseNotes";
+    public static final String UPDATE_NOTES_TASK = "updateReleaseNotes";
+    private static final String PREVIEW_NOTES_TASK = "previewReleaseNotes";
+
     public void apply(final Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
         project.getPlugins().apply(VersioningPlugin.class);
@@ -34,7 +38,7 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
     }
 
     private static void releaseNotesTasks(final Project project, final ReleaseConfiguration conf) {
-        final ReleaseNotesFetcherTask fetcher = TaskMaker.task(project, "fetchReleaseNotes", ReleaseNotesFetcherTask.class, new Action<ReleaseNotesFetcherTask>() {
+        final ReleaseNotesFetcherTask fetcher = TaskMaker.task(project, FETCH_NOTES_TASK, ReleaseNotesFetcherTask.class, new Action<ReleaseNotesFetcherTask>() {
             public void execute(final ReleaseNotesFetcherTask t) {
                 t.setDescription("Fetches release notes data from Git and GitHub and serializes them to a file");
                 t.setOutputFile(new File(project.getBuildDir(), "detailed-release-notes.ser"));
@@ -49,14 +53,14 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
             }
         });
 
-        TaskMaker.task(project, "updateReleaseNotes", IncrementalReleaseNotes.UpdateTask.class, new Action<IncrementalReleaseNotes.UpdateTask>() {
+        TaskMaker.task(project, UPDATE_NOTES_TASK, IncrementalReleaseNotes.UpdateTask.class, new Action<IncrementalReleaseNotes.UpdateTask>() {
             public void execute(final IncrementalReleaseNotes.UpdateTask t) {
                 t.setDescription("Updates release notes file.");
                 configureDetailedNotes(t, fetcher, project, conf);
             }
         });
 
-        TaskMaker.task(project, "previewReleaseNotes", IncrementalReleaseNotes.PreviewTask.class, new Action<IncrementalReleaseNotes.PreviewTask>() {
+        TaskMaker.task(project, PREVIEW_NOTES_TASK, IncrementalReleaseNotes.PreviewTask.class, new Action<IncrementalReleaseNotes.PreviewTask>() {
             public void execute(final IncrementalReleaseNotes.PreviewTask t) {
                 t.setDescription("Shows new incremental content of release notes. Useful for previewing the release notes.");
                 configureDetailedNotes(t, fetcher, project, conf);

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
@@ -17,8 +17,10 @@ import static org.mockito.release.internal.gradle.configuration.DeferredConfigur
  * The plugin adds following tasks:
  *
  * <ul>
- *     <li>updateReleaseNotes - updates release notes file in place.</li>
- *     <li>previewReleaseNotes - prints incremental release notes to the console for preview.</li>
+ *     <li>fetchReleaseNotes - fetches release notes data, see {@link ReleaseNotesFetcherTask}</li>
+ *     <li>updateReleaseNotes - updates release notes file in place, see {@link IncrementalReleaseNotes.UpdateTask}</li>
+ *     <li>previewReleaseNotes - prints incremental release notes to the console for preview,
+ *          see {@link IncrementalReleaseNotes.PreviewTask}</li>
  * </ul>
  */
 public class ReleaseNotesPlugin implements Plugin<Project> {

--- a/src/main/groovy/org/mockito/release/version/DefaultVersionInfo.java
+++ b/src/main/groovy/org/mockito/release/version/DefaultVersionInfo.java
@@ -69,6 +69,10 @@ class DefaultVersionInfo implements VersionInfo {
         return previousVersion;
     }
 
+    public DefaultVersionInfo bumpVersion() {
+        return bumpVersion(false);
+    }
+
     public DefaultVersionInfo bumpVersion(boolean updateNotable) {
         String content = IOUtil.readFully(versionFile);
         if (updateNotable) {
@@ -103,6 +107,8 @@ class DefaultVersionInfo implements VersionInfo {
     }
 
     public Collection<String> getNotableVersions() {
+        //TODO if by the end of Q3 (9/30/17) we don't find the concept of 'notable versions' useful
+        //we should delete 'notableVersions' code from this class
         return notableVersions;
     }
 

--- a/src/main/groovy/org/mockito/release/version/DefaultVersionInfo.java
+++ b/src/main/groovy/org/mockito/release/version/DefaultVersionInfo.java
@@ -111,8 +111,4 @@ class DefaultVersionInfo implements VersionInfo {
         //we should delete 'notableVersions' code from this class
         return notableVersions;
     }
-
-    public boolean isNotableRelease() {
-        return version.endsWith(".0.0");
-    }
 }

--- a/src/main/groovy/org/mockito/release/version/DefaultVersionInfo.java
+++ b/src/main/groovy/org/mockito/release/version/DefaultVersionInfo.java
@@ -113,7 +113,6 @@ class DefaultVersionInfo implements VersionInfo {
     }
 
     public boolean isNotableRelease() {
-        //TODO also check for env variable here / commit message, we already check for 'TRAVIS_COMMIT_MESSAGE' elsewhere
-        return version.endsWith(".0") || version.endsWith(".0.0");
+        return version.endsWith(".0.0");
     }
 }

--- a/src/main/groovy/org/mockito/release/version/VersionInfo.java
+++ b/src/main/groovy/org/mockito/release/version/VersionInfo.java
@@ -20,9 +20,4 @@ public interface VersionInfo {
      * and returns incremented version info instance.
      */
     VersionInfo bumpVersion();
-
-    /**
-     * Informs if the current version is a notable release
-     */
-    boolean isNotableRelease();
 }

--- a/src/main/groovy/org/mockito/release/version/VersionInfo.java
+++ b/src/main/groovy/org/mockito/release/version/VersionInfo.java
@@ -1,7 +1,5 @@
 package org.mockito.release.version;
 
-import java.util.Collection;
-
 /**
  * The file that contains version number
  */
@@ -20,15 +18,8 @@ public interface VersionInfo {
     /**
      * Increments version number in the backing object (typically a file)
      * and returns incremented version info instance.
-     *
-     * @param updateNotable if true, the previous version will be included in the notable versions, too.
      */
-    VersionInfo bumpVersion(boolean updateNotable);
-
-    /**
-     * Returns notable versions
-     */
-    Collection<String> getNotableVersions();
+    VersionInfo bumpVersion();
 
     /**
      * Informs if the current version is a notable release

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPluginTest.groovy
@@ -39,20 +39,4 @@ class ReleaseConfigurationPluginTest extends Specification {
         ""       | true
         null     | true
     }
-
-    def "knows if the release is not notable"() {
-        def conf = root.plugins.apply(ReleaseConfigurationPlugin).configuration
-
-        expect: !conf.notableRelease
-
-        when: conf.notableRelease = true
-        then: conf.notableRelease
-    }
-
-    def "knows if the release is notable"() {
-        root.file("version.properties") << "version=1.5.0"
-
-        expect:
-        root.plugins.apply(ReleaseConfigurationPlugin).configuration.notableRelease
-    }
 }

--- a/src/test/groovy/org/mockito/release/internal/gradle/VersioningPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/VersioningPluginTest.groovy
@@ -68,6 +68,5 @@ class VersioningPluginTest extends Specification {
         versionInfo.versionFile == project.file(VersioningPlugin.VERSION_FILE_NAME)
         versionInfo.version == "1.0.0"
         versionInfo.notableVersions == ["0.1.0"] as LinkedList
-        versionInfo.notableRelease
     }
 }


### PR DESCRIPTION
For motivation, see #157. Let's cut down features before 1.0 to keep the library simple. Best to review commit by commit.

 - removed 'notable releases' concept for now. I left some internal logic for now in case we need to salvage it.
 - refactorings, tidy-ups, javadoc

Tested with:
 - mockito
 - example