### PR TITLE
Shipkit.gradle loaded from relative not absolute path

### DIFF
--- a/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPlugin.java
@@ -127,7 +127,7 @@ public class ContinuousDeliveryPlugin implements Plugin<Project> {
                         "Ship with: './gradlew performRelease -Preleasing.dryRun=false'. " +
                         "Test with: './gradlew testRelease'");
 
-                t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, "updateReleaseNotes", "updateNotableReleaseNotes");
+                t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, "updateReleaseNotes");
                 t.dependsOn(GitPlugin.PERFORM_GIT_PUSH_TASK);
                 t.dependsOn("bintrayUploadAll");
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseConfigurationPlugin.java
@@ -68,7 +68,7 @@ public class ReleaseConfigurationPlugin implements Plugin<Project> {
             rootProject.apply(new Action<ObjectConfigurationAction>() {
                 @Override
                 public void execute(ObjectConfigurationAction objectConfigurationAction) {
-                    objectConfigurationAction.from(configFile);
+                    objectConfigurationAction.from(CONFIG_FILE_RELATIVE_PATH);
                 }
             });
         }

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
@@ -47,14 +47,10 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
                 t.setDescription("Fetches release notes data from Git and GitHub and serializes them to a file");
                 t.setOutputFile(new File(project.getBuildDir(), "detailed-release-notes.ser"));
 
-                deferredConfiguration(project, new Runnable() {
-                    public void run() {
-                        t.setGitHubReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
-                        t.setGitHubRepository(conf.getGitHub().getRepository());
-                        t.setPreviousVersion(conf.getPreviousReleaseVersion());
-                        t.setIgnoreCommitsContaining(conf.getReleaseNotes().getIgnoreCommitsContaining());
-                    }
-                });
+                t.setGitHubReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
+                t.setGitHubRepository(conf.getGitHub().getRepository());
+                t.setPreviousVersion(conf.getPreviousReleaseVersion());
+                t.setIgnoreCommitsContaining(conf.getReleaseNotes().getIgnoreCommitsContaining());
             }
         });
 

--- a/src/test/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPluginTest.groovy
@@ -5,6 +5,10 @@ import testutil.PluginSpecification
 class ContinuousDeliveryPluginTest extends PluginSpecification {
 
     def "applies"() {
+        given:
+        def conf = project.plugins.apply(ReleaseConfigurationPlugin).configuration
+        conf.gitHub.readOnlyAuthToken = "token"
+        conf.gitHub.repository = "repo"
         expect:
         project.plugins.apply("org.mockito.mockito-release-tools.continuous-delivery")
     }

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseNotesPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseNotesPluginTest.groovy
@@ -4,6 +4,12 @@ import testutil.PluginSpecification
 
 class ReleaseNotesPluginTest extends PluginSpecification {
 
+    void setup(){
+        def conf = project.plugins.apply(ReleaseConfigurationPlugin).configuration
+        conf.gitHub.readOnlyAuthToken = "token"
+        conf.gitHub.repository = "repo"
+    }
+
     def "applies cleanly"() {
         expect:
         project.plugins.apply("org.mockito.release-notes")


### PR DESCRIPTION
Also redundant updateNotableReleaseNotes task removed and deferredConfiguration is also not needed anymore in ReleaseNotesPlugin