### PR TITLE
Ensured git push runs as late as possible

### DIFF
--- a/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/BaseJavaLibraryPlugin.java
@@ -44,8 +44,8 @@ public class BaseJavaLibraryPlugin implements Plugin<Project> {
 
     final static String PUBLICATION_NAME = "javaLibrary";
     final static String POM_TASK = "generatePomFileFor" + capitalize(PUBLICATION_NAME) + "Publication";
-    public static final String SOURCES_JAR_TASK = "sourcesJar";
-
+    final static String MAVEN_LOCAL_TASK = "publish" + capitalize(PUBLICATION_NAME) + "PublicationToMavenLocal";
+    final static String SOURCES_JAR_TASK = "sourcesJar";
 
     public void apply(final Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();

--- a/src/main/groovy/org/mockito/release/internal/gradle/GitPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/GitPlugin.java
@@ -86,9 +86,16 @@ public class GitPlugin implements Plugin<Project> {
                 t.mustRunAfter(GIT_COMMIT_TASK);
                 t.mustRunAfter(GIT_TAG_TASK);
 
+                t.doFirst(new Action<Task>() {
+                    public void execute(Task task) {
+                        //Getting the branch during task execution time so that integ testing is easier
+                        //TODO revisit. How can we make integ testing easy without using doFirst to configure tasks?
+                        String branch = gitStatus.getBranch();
+                        t.setCommandLine(GitUtil.getGitPushArgs(conf, gitStatus.getBranch()));
+                    }
+                });
                 lazyConfiguration(t, new Runnable() {
                     public void run() {
-                        t.setCommandLine(GitUtil.getGitPushArgs(conf, gitStatus.getBranch()));
                         t.setSecretValue(conf.getGitHub().getWriteAuthToken());
                     }
                 });

--- a/src/test/groovy/org/mockito/release/gradle/ContinuousDeliveryPluginIntegTest.groovy
+++ b/src/test/groovy/org/mockito/release/gradle/ContinuousDeliveryPluginIntegTest.groovy
@@ -1,0 +1,87 @@
+package org.mockito.release.gradle
+
+import testutil.GradleSpecification
+
+class ContinuousDeliveryPluginIntegTest extends GradleSpecification {
+
+    def "all tasks in dry run"() {
+
+        /**
+         * TODO this test is just a starting point we will make it better and create more integration tests
+         * Stuff that we should do:
+         *  1. (Most important) Avoid writing too many integration tests. Most code should be covered by unit tests (see testing pyramid)
+         *  2. Push out complexity to base class GradleSpecification
+         *      so that what remains in the test is the essential part of a tested feature
+         *  3. Add more specific assertions rather than just a list of tasks in dry run mode
+         *  4. Use sensible defaults so that we don't need to specify all configuration in the test
+         *  5. Move integration tests to a separate module
+         *  6. Dependencies are hardcoded between GradleSpecification and build.gradle of release-tools project
+         */
+
+        projectDir.newFolder("gradle")
+        projectDir.newFile("gradle/shipkit.gradle") << """
+            releasing {
+                gitHub.readOnlyAuthToken = "foo"
+                gitHub.writeAuthToken = "secret"
+                releasing.releaseNotes.file = "CHANGELOG.md"
+                releasing.git.user = "shipkit"
+                releasing.git.email = "shipkit@gmail.com"
+                releasing.gitHub.repository = "repo"
+            }
+            
+            allprojects {
+                plugins.withId("org.mockito.mockito-release-tools.java-library") {
+                    bintray {
+                        user = "szczepiq"
+                        key = "secret"
+                    }
+                }
+            }
+        """
+
+        buildFile << """
+            apply plugin: "org.mockito.mockito-release-tools.continuous-delivery"
+        """
+
+        settingsFile << "include 'api', 'impl'"
+        projectDir.newFile("version.properties") << "version=1.0.0"
+        projectDir.newFolder('api')
+        projectDir.newFolder('impl')
+        projectDir.newFile('api/build.gradle') << "apply plugin: 'org.mockito.mockito-release-tools.java-library'"
+        projectDir.newFile('impl/build.gradle') << "apply plugin: 'org.mockito.mockito-release-tools.java-library'"
+
+        expect:
+        def result = pass("performRelease", "-m")
+        //git push and bintray upload tasks should run as late as possible
+        result.tasks.join("\n") == """:fetchAllContributors=SKIPPED
+:api:generatePomFileForJavaLibraryPublication=SKIPPED
+:api:compileJava=SKIPPED
+:api:processResources=SKIPPED
+:api:classes=SKIPPED
+:api:jar=SKIPPED
+:api:javadoc=SKIPPED
+:api:javadocJar=SKIPPED
+:api:sourcesJar=SKIPPED
+:api:publishJavaLibraryPublicationToMavenLocal=SKIPPED
+:impl:generatePomFileForJavaLibraryPublication=SKIPPED
+:impl:compileJava=SKIPPED
+:impl:processResources=SKIPPED
+:impl:classes=SKIPPED
+:impl:jar=SKIPPED
+:impl:javadoc=SKIPPED
+:impl:javadocJar=SKIPPED
+:impl:sourcesJar=SKIPPED
+:impl:publishJavaLibraryPublicationToMavenLocal=SKIPPED
+:bumpVersionFile=SKIPPED
+:fetchReleaseNotes=SKIPPED
+:updateReleaseNotes=SKIPPED
+:gitCommit=SKIPPED
+:gitTag=SKIPPED
+:gitPush=SKIPPED
+:api:bintrayUpload=SKIPPED
+:impl:bintrayUpload=SKIPPED
+:bintrayUploadAll=SKIPPED
+:performGitPush=SKIPPED
+:performRelease=SKIPPED"""
+    }
+}

--- a/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/src/test/groovy/testutil/GradleSpecification.groovy
@@ -18,6 +18,7 @@ class GradleSpecification extends Specification {
     final TemporaryFolder projectDir = new TemporaryFolder()
 
     File buildFile
+    File settingsFile
 
     private final static File CLASSES_DIR = findClassesDir();
     private final static File RESOURCES_DIR = findResourcesDir();
@@ -28,8 +29,15 @@ class GradleSpecification extends Specification {
             dependencies {
                 classpath files("${CLASSES_DIR.absolutePath}")
                 classpath files("${RESOURCES_DIR.absolutePath}")
+                classpath "com.github.cliftonlabs:json-simple:2.1.2"
+                classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
+            }
+            
+            repositories {
+                jcenter()
             }
         }"""
+        settingsFile = projectDir.newFile('settings.gradle')
     }
 
     /**


### PR DESCRIPTION
1. Added initial integration test. It adds reasonable coverage and also helped me a lot implement git push / bintray upload ordering rules. We should grow our integration test suite and also improve the base class so that it is easy to write more integration tests. However, we should never have too many integration tests. Most code will be tested with unit tests (see testing pyramid pattern). There is a big fat TODO in the test. We will make it better soon.
2. git push now runs late in the release process ensuring that when there is a failure we don't push code first.
3. changed a bit how git push is configured so that the branch is configured in the 'doFirst' action. This should be fine for now.

Fixes #149