### PR TITLE
AutoReleaseNotesPlugin introduced

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,12 @@ pluginBundle {
             displayName = 'Mockito automated release notes generation plugin'
         }
 
+        autoReleaseNotesPlugin {
+            id = 'org.mockito.mockito-release-tools.auto-release-notes'
+            displayName = 'Mockito plugin for automated release notes generation and publishing released changes to VCS'
+            tags = ['mockito', 'continuous delivery', 'release notes', 'changelog']
+        }
+
         autoVersioningPlugin {
             id = 'org.mockito.release-tools.auto-versioning'
             displayName = 'Mockito automated versioning plugin'

--- a/src/main/groovy/org/mockito/release/internal/gradle/AutoReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/AutoReleaseNotesPlugin.java
@@ -1,0 +1,36 @@
+package org.mockito.release.internal.gradle;
+
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.mockito.release.internal.gradle.util.TaskMaker;
+
+/**
+ *  Combines plugins that allow updating release notes and pushing the results to the repository
+ *
+ *  * Applies following plugins and preconfigures tasks provided by those plugins:
+ *
+ * <ul>
+ *     <li>{@link GitPlugin}</li>
+ *     <li>{@link ReleaseNotesPlugin}</li>
+ * </ul>
+ */
+public class AutoReleaseNotesPlugin implements Plugin<Project> {
+
+    private static final String PERFORM_RELEASE_NOTES_UPDATE = "performReleaseNotesUpdate";
+
+    @Override
+    public void apply(Project project) {
+        project.getPlugins().apply(GitPlugin.class);
+        project.getPlugins().apply(ReleaseNotesPlugin.class);
+
+        TaskMaker.task(project, PERFORM_RELEASE_NOTES_UPDATE, new Action<Task>() {
+            public void execute(Task t) {
+                t.setDescription("Updates release notes, commits and pushes changes to Git repository");
+                t.dependsOn(ReleaseNotesPlugin.UPDATE_NOTES_TASK);
+                t.dependsOn(GitPlugin.PERFORM_GIT_PUSH_TASK);
+            }
+        });
+    }
+}

--- a/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ContributorsPlugin.java
@@ -6,7 +6,6 @@ import org.gradle.api.Project;
 import org.mockito.release.gradle.ReleaseConfiguration;
 import org.mockito.release.internal.gradle.util.TaskMaker;
 
-import static org.mockito.release.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
 import static org.mockito.release.internal.gradle.util.BuildConventions.contributorsFile;
 
 /**
@@ -32,15 +31,9 @@ public class ContributorsPlugin implements Plugin<Project> {
                 task.setGroup(TaskMaker.TASK_GROUP);
                 task.setDescription("Fetch info about all project contributors from GitHub and store it in file");
                 task.setOutputFile(contributorsFile(project));
-
-                deferredConfiguration(project, new Runnable() {
-                    @Override
-                    public void run() {
-                        task.setReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
-                        task.setRepository(conf.getGitHub().getRepository());
-                        task.setEnabled(conf.getTeam().getContributors().isEmpty());
-                    }
-                });
+                task.setReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
+                task.setRepository(conf.getGitHub().getRepository());
+                task.setEnabled(conf.getTeam().getContributors().isEmpty());
             }
         });
 

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNeededPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNeededPlugin.java
@@ -9,7 +9,6 @@ import org.mockito.release.gradle.ReleaseNeededTask;
 import org.mockito.release.internal.comparison.PublicationsComparatorTask;
 import org.mockito.release.internal.gradle.util.TaskMaker;
 
-import static org.mockito.release.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
 import static org.mockito.release.internal.gradle.configuration.LazyConfiguration.lazyConfiguration;
 
 /**
@@ -70,11 +69,8 @@ public class ReleaseNeededPlugin implements Plugin<Project> {
                     }
                 });
 
-                deferredConfiguration(project, new Runnable() {
-                    public void run() {
-                        t.setReleasableBranchRegex(conf.getGit().getReleasableBranchRegex());
-                    }
-                });
+                t.setReleasableBranchRegex(conf.getGit().getReleasableBranchRegex());
+
                 lazyConfiguration(t, new Runnable() {
                     public void run() {
                         //if the user or some other task have configured the branch, don't overwrite it

--- a/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/mockito/release/internal/gradle/ReleaseNotesPlugin.java
@@ -80,16 +80,18 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
                                                final AllContributorsFetcherTask contributorsFetcher) {
         task.dependsOn(releaseNotesFetcher);
         task.dependsOn(contributorsFetcher);
+
+        task.setDevelopers(conf.getTeam().getDevelopers());
+        task.setContributors(conf.getTeam().getContributors());
+        task.setGitHubLabelMapping(conf.getReleaseNotes().getLabelMapping()); //TODO make it optional
+        task.setReleaseNotesFile(project.file(conf.getReleaseNotes().getFile())); //TODO add sensible defaul
+        task.setGitHubRepository(conf.getGitHub().getRepository());
+        task.setPreviousVersion(project.getExtensions().getByType(VersionInfo.class).getPreviousVersion());
+
         deferredConfiguration(project, new Runnable() {
             public void run() {
                 task.setReleaseNotesData(releaseNotesFetcher.getOutputFile());
-                task.setDevelopers(conf.getTeam().getDevelopers());
-                task.setContributors(conf.getTeam().getContributors());
                 task.setContributorsDataFile(contributorsFetcher.getOutputFile());
-                task.setGitHubLabelMapping(conf.getReleaseNotes().getLabelMapping()); //TODO make it optional
-                task.setReleaseNotesFile(project.file(conf.getReleaseNotes().getFile())); //TODO add sensible default
-                task.setGitHubRepository(conf.getGitHub().getRepository());
-                task.setPreviousVersion(project.getExtensions().getByType(VersionInfo.class).getPreviousVersion());
             }
         });
     }

--- a/src/main/resources/META-INF/gradle-plugins/org.mockito.mockito-release-notes.auto-release-notes.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.mockito.mockito-release-notes.auto-release-notes.properties
@@ -1,0 +1,1 @@
+implementation-class=org.mockito.release.internal.gradle.AutoReleaseNotesPlugin

--- a/src/test/groovy/org/mockito/release/internal/gradle/AutoReleaseNotesPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/AutoReleaseNotesPluginTest.groovy
@@ -2,8 +2,7 @@ package org.mockito.release.internal.gradle
 
 import testutil.PluginSpecification
 
-class ContributorsPluginTest extends PluginSpecification {
-
+class AutoReleaseNotesPluginTest extends PluginSpecification {
     def "applies"() {
         given:
         def conf = applyReleaseConfiguration()
@@ -11,6 +10,7 @@ class ContributorsPluginTest extends PluginSpecification {
         conf.gitHub.repository = "repo"
 
         expect:
-        project.plugins.apply("org.mockito.release-tools.contributors")
+        project.plugins.apply("org.mockito.mockito-release-notes.auto-release-notes")
     }
+
 }

--- a/src/test/groovy/org/mockito/release/internal/gradle/AutoReleaseNotesPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/AutoReleaseNotesPluginTest.groovy
@@ -4,11 +4,6 @@ import testutil.PluginSpecification
 
 class AutoReleaseNotesPluginTest extends PluginSpecification {
     def "applies"() {
-        given:
-        def conf = applyReleaseConfiguration()
-        conf.gitHub.readOnlyAuthToken = "token"
-        conf.gitHub.repository = "repo"
-
         expect:
         project.plugins.apply("org.mockito.mockito-release-notes.auto-release-notes")
     }

--- a/src/test/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ContinuousDeliveryPluginTest.groovy
@@ -5,10 +5,6 @@ import testutil.PluginSpecification
 class ContinuousDeliveryPluginTest extends PluginSpecification {
 
     def "applies"() {
-        given:
-        def conf = project.plugins.apply(ReleaseConfigurationPlugin).configuration
-        conf.gitHub.readOnlyAuthToken = "token"
-        conf.gitHub.repository = "repo"
         expect:
         project.plugins.apply("org.mockito.mockito-release-tools.continuous-delivery")
     }

--- a/src/test/groovy/org/mockito/release/internal/gradle/ContributorsPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ContributorsPluginTest.groovy
@@ -5,11 +5,6 @@ import testutil.PluginSpecification
 class ContributorsPluginTest extends PluginSpecification {
 
     def "applies"() {
-        given:
-        def conf = applyReleaseConfiguration()
-        conf.gitHub.readOnlyAuthToken = "token"
-        conf.gitHub.repository = "repo"
-
         expect:
         project.plugins.apply("org.mockito.release-tools.contributors")
     }

--- a/src/test/groovy/org/mockito/release/internal/gradle/ReleaseNotesPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/ReleaseNotesPluginTest.groovy
@@ -4,12 +4,6 @@ import testutil.PluginSpecification
 
 class ReleaseNotesPluginTest extends PluginSpecification {
 
-    void setup(){
-        def conf = project.plugins.apply(ReleaseConfigurationPlugin).configuration
-        conf.gitHub.readOnlyAuthToken = "token"
-        conf.gitHub.repository = "repo"
-    }
-
     def "applies cleanly"() {
         expect:
         project.plugins.apply("org.mockito.release-notes")

--- a/src/test/groovy/org/mockito/release/internal/gradle/VersioningPluginTest.groovy
+++ b/src/test/groovy/org/mockito/release/internal/gradle/VersioningPluginTest.groovy
@@ -72,4 +72,9 @@ class VersioningPluginTest extends PluginSpecification {
         gitCommitTask.files.contains(project.file(VersioningPlugin.VERSION_FILE_NAME).absolutePath)
         gitCommitTask.aggregatedCommitMessage.contains("version bumped")
     }
+
+    @Override
+    void configureReleaseConfigurationDefaults(){
+        // ReleaseConfiguration is not needed in this test
+    }
 }

--- a/src/test/groovy/testutil/PluginSpecification.groovy
+++ b/src/test/groovy/testutil/PluginSpecification.groovy
@@ -4,6 +4,7 @@ import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import org.mockito.release.gradle.ReleaseConfiguration
 import org.mockito.release.internal.gradle.ReleaseConfigurationPlugin
 import org.mockito.release.notes.util.IOUtil
 import spock.lang.Specification
@@ -35,5 +36,9 @@ class PluginSpecification extends Specification{
         def configFile = new File(rootPath + "/" + ReleaseConfigurationPlugin.CONFIG_FILE_RELATIVE_PATH);
         IOUtil.createParentDirectory(configFile)
         configFile << "releasing { }"
+    }
+
+    ReleaseConfiguration applyReleaseConfiguration(){
+        return project.plugins.apply(ReleaseConfigurationPlugin).configuration
     }
 }

--- a/src/test/groovy/testutil/PluginSpecification.groovy
+++ b/src/test/groovy/testutil/PluginSpecification.groovy
@@ -25,6 +25,7 @@ class PluginSpecification extends Specification{
     void setup(){
         initProject()
         createConfigFile()
+        configureReleaseConfigurationDefaults()
     }
 
     void initProject() {
@@ -40,5 +41,11 @@ class PluginSpecification extends Specification{
 
     ReleaseConfiguration applyReleaseConfiguration(){
         return project.plugins.apply(ReleaseConfigurationPlugin).configuration
+    }
+
+    void configureReleaseConfigurationDefaults(){
+        def conf = applyReleaseConfiguration()
+        conf.gitHub.readOnlyAuthToken = "token"
+        conf.gitHub.repository = "repo"
     }
 }


### PR DESCRIPTION
AutoReleaseNotesPlugin, plugin similar functionally to AutoVersioningPlugin introduced. It is the previous to last step of release notes dogfooding in MRT. I'm not sure about naming though. @szczepiq what do you think?

I also removed deferredConfiguration for properties based on ReleaseConfiguration since it is now loaded eagerly. 