### PR TITLE
fix missing contributors in the release notes file bug

### DIFF
--- a/src/main/groovy/org/mockito/release/notes/vcs/DefaultContributionSetSerializer.java
+++ b/src/main/groovy/org/mockito/release/notes/vcs/DefaultContributionSetSerializer.java
@@ -39,7 +39,7 @@ public class DefaultContributionSetSerializer {
 
     private DefaultContributionSet addCommits(DefaultContributionSet defaultContributionSet, JsonArray commits) {
         for (int i = 0; i < commits.size(); i++) {
-            Commit commit = gitCommitSerializer.deserialize((JsonObject) commits.get(0));
+            Commit commit = gitCommitSerializer.deserialize((JsonObject) commits.get(i));
             defaultContributionSet.add(commit);
         }
         return defaultContributionSet;


### PR DESCRIPTION
fixes  #184

the generated release notes do contain all contributions again. Executing the sample provided by @szczepiq in the linked issue results in:

> ----------------
> **2.8.37** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.36...v2.8.37) by [epeee](https://github.com/epeee) (3), [Szczepan Faber](http://github.com/szczepiq) (1) - *2017-05-29* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.37-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.37)
>  - update gradle to v3.5 [(#1099)](https://github.com/mockito/mockito/pull/1099)
>  - Moved some more dependencies to dependencies.gradle [(#1098)](https://github.com/mockito/mockito/pull/1098)
> 
> ----------------

I will provide tests later on (maybe in a separate pr if we'd like to have the problem fixed immediately).