### PR TITLE
Date placement in release notes

### DIFF
--- a/src/main/groovy/org/shipkit/notes/format/DetailedFormatter.java
+++ b/src/main/groovy/org/shipkit/notes/format/DetailedFormatter.java
@@ -38,7 +38,7 @@ class DetailedFormatter implements MultiReleaseNotesFormatter {
         }
 
         for (ReleaseNotesData d : data) {
-            sb.append("**").append(d.getVersion()).append("** - ");
+            sb.append("**").append(d.getVersion()).append(" (").append(DateFormat.formatDate(d.getDate())).append(")** - ");
             String vcsCommitsLink = MessageFormat.format(vcsCommitsLinkTemplate, d.getPreviousVersionVcsTag(), d.getVcsTag());
             sb.append(releaseSummary(d.getVersion(), d.getDate(), d.getContributions(), contributors, vcsCommitsLink, publicationRepository));
 
@@ -56,7 +56,7 @@ class DetailedFormatter implements MultiReleaseNotesFormatter {
     static String releaseSummary(String version, Date date, ContributionSet contributions, Map<String, Contributor> contributors,
                                  String vcsCommitsLink, String publicationRepository) {
         return authorsSummary(contributions, contributors, vcsCommitsLink) +
-                " - *" + DateFormat.formatDate(date) + "*" + " - published to " + getBintrayBadge(version, publicationRepository) + "\n" +
+                " - published to " + getBintrayBadge(version, publicationRepository) + "\n" +
                 authorsSummaryAppendix(contributions, contributors);
     }
 

--- a/src/test/groovy/org/shipkit/notes/format/DetailedFormatterTest.groovy
+++ b/src/test/groovy/org/shipkit/notes/format/DetailedFormatterTest.groovy
@@ -27,9 +27,9 @@ No release information."""
         expect:
         f.formatReleaseNotes([d1, d2]) == """Release notes:
 
-**2.0.0** - no code changes (no commits) - *2017-01-04* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.0.0-green.svg)](Bintray/2.0.0)
+**2.0.0 (2017-01-04)** - no code changes (no commits) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.0.0-green.svg)](Bintray/2.0.0)
 
-**1.9.0** - no code changes (no commits) - *2016-12-30* - published to [![Bintray](https://img.shields.io/badge/Bintray-1.9.0-green.svg)](Bintray/1.9.0)"""
+**1.9.0 (2016-12-30)** - no code changes (no commits) - published to [![Bintray](https://img.shields.io/badge/Bintray-1.9.0-green.svg)](Bintray/1.9.0)"""
     }
 
     def "no improvements"() {
@@ -46,7 +46,7 @@ No release information."""
         expect:
         f.formatReleaseNotes([d]) == """Release notes:
 
-**2.0.0** - [1 commit](http://commits/v1.9.0...v2.0.0) by Szczepan Faber - *2017-01-04* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.0.0-green.svg)](Bintray/2.0.0)
+**2.0.0 (2017-01-04)** - [1 commit](http://commits/v1.9.0...v2.0.0) by Szczepan Faber - published to [![Bintray](https://img.shields.io/badge/Bintray-2.0.0-green.svg)](Bintray/2.0.0)
  - No pull requests referenced in commit messages."""
     }
 
@@ -142,7 +142,7 @@ No release information."""
                 "https://bintray.com/shipkit")
 
         expect:
-        summary == """[100 commits](link) by 4 authors - *2017-01-04* - published to [![Bintray](https://img.shields.io/badge/Bintray-1.2.3-green.svg)](https://bintray.com/shipkit/1.2.3)
+        summary == """[100 commits](link) by 4 authors - published to [![Bintray](https://img.shields.io/badge/Bintray-1.2.3-green.svg)](https://bintray.com/shipkit/1.2.3)
  - Commits: Szczepan Faber (40), Brice Dutheil (30), Rafael Winterhalter (20), Tim van der Lippe (10)
 """
     }


### PR DESCRIPTION
fixes #171

moved the date to the new location. Did some testing using mockito project:

> **2.8.37 (2017-05-29)** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.36...v2.8.37) by epeee (3), [Szczepan Faber](http://github.com/szczepiq) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.37-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.37)
