### PR TITLE
Simplified task model, made gitPush run before bintrayUpload

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
@@ -110,6 +110,8 @@ public class ShipkitJavaPlugin implements Plugin<Project> {
                         bintrayUpload.mustRunAfter(gitPush);
 
                         final BintrayExtension bintray = subproject.getExtensions().getByType(BintrayExtension.class);
+                        //TODO clean up below. We don't need 'deferredConfiguration' because at this point
+                        // shipkit file was already loaded and java library plugin applied on the subproject
                         deferredConfiguration(subproject, new Runnable() {
                             public void run() {
                                 configurePublicationRepo(project, BintrayUtil.getRepoLink(bintray));

--- a/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
@@ -76,9 +76,6 @@ public class ShipkitJavaPlugin implements Plugin<Project> {
             }
         });
 
-        //TODO we should have tasks from the same plugin to have the same group
-        //let's have a task maker instance in a plugin that has sets the group accordingly
-
         final Task bintrayUploadAll = TaskMaker.task(project, "bintrayUploadAll", new Action<Task>() {
             public void execute(Task t) {
                 t.setDescription("Depends on all 'bintrayUpload' tasks from all Gradle projects.");

--- a/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
@@ -91,15 +91,15 @@ public class ShipkitJavaPlugin implements Plugin<Project> {
 
                         //Making git push run as late as possible because it is an operation that is hard to reverse.
                         //Git push will be executed after all tasks needed by bintrayUpload
-                        // but before bintrayUpload (configured elsewhere).
+                        // but before bintrayUpload.
                         //Using task path as String because the task comes from maven-publish new configuration model
-                        // and we cannot refer to it in a normal way.
+                        // and we cannot refer to it in a normal way, by task instance.
                         String mavenLocalTask = subproject.getPath() + ":" + MAVEN_LOCAL_TASK;
                         Task gitPush = project.getTasks().getByName(GitPlugin.GIT_PUSH_TASK);
-                        gitPush.shouldRunAfter(mavenLocalTask);
-                        //It is safer to run bintray upload after git push (hard to reverse operation)
-                        //This way, when git push fails we don't publish jars to bintray
-                        bintrayUpload.shouldRunAfter(gitPush);
+                        gitPush.mustRunAfter(mavenLocalTask);
+                        //bintray upload after git push so that when git push fails we don't publish jars to bintray
+                        //git push is easier to undo than deleting published jars (not possible with Central)
+                        bintrayUpload.mustRunAfter(gitPush);
 
                         final BintrayExtension bintray = subproject.getExtensions().getByType(BintrayExtension.class);
                         deferredConfiguration(subproject, new Runnable() {

--- a/src/test/groovy/org/shipkit/gradle/ShipkitJavaPluginIntegTest.groovy
+++ b/src/test/groovy/org/shipkit/gradle/ShipkitJavaPluginIntegTest.groovy
@@ -80,7 +80,6 @@ class ShipkitJavaPluginIntegTest extends GradleSpecification {
 :gitPush=SKIPPED
 :api:bintrayUpload=SKIPPED
 :impl:bintrayUpload=SKIPPED
-:bintrayUploadAll=SKIPPED
 :performGitPush=SKIPPED
 :performRelease=SKIPPED"""
     }

--- a/src/test/groovy/org/shipkit/gradle/ShipkitJavaPluginIntegTest.groovy
+++ b/src/test/groovy/org/shipkit/gradle/ShipkitJavaPluginIntegTest.groovy
@@ -53,7 +53,12 @@ class ShipkitJavaPluginIntegTest extends GradleSpecification {
         expect:
         def result = pass("performRelease", "-m")
         //git push and bintray upload tasks should run as late as possible
-        result.tasks.join("\n") == """:fetchAllContributors=SKIPPED
+        result.tasks.join("\n") == """:bumpVersionFile=SKIPPED
+:fetchAllContributors=SKIPPED
+:fetchReleaseNotes=SKIPPED
+:updateReleaseNotes=SKIPPED
+:gitCommit=SKIPPED
+:gitTag=SKIPPED
 :api:generatePomFileForJavaLibraryPublication=SKIPPED
 :api:compileJava=SKIPPED
 :api:processResources=SKIPPED
@@ -72,15 +77,10 @@ class ShipkitJavaPluginIntegTest extends GradleSpecification {
 :impl:javadocJar=SKIPPED
 :impl:sourcesJar=SKIPPED
 :impl:publishJavaLibraryPublicationToMavenLocal=SKIPPED
-:bumpVersionFile=SKIPPED
-:fetchReleaseNotes=SKIPPED
-:updateReleaseNotes=SKIPPED
-:gitCommit=SKIPPED
-:gitTag=SKIPPED
 :gitPush=SKIPPED
+:performGitPush=SKIPPED
 :api:bintrayUpload=SKIPPED
 :impl:bintrayUpload=SKIPPED
-:performGitPush=SKIPPED
 :performRelease=SKIPPED"""
     }
 }


### PR DESCRIPTION
Best to review commit by commit

- Removed task 'bintrayUploadAll' to drive simplicity
- Used mustRunAfter instead of shouldRunAfter (fixes #182)

For motivation on the changes, please review commit-by-commit