### PR TITLE
Expose "version" and "tagPrefix" as task properties

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/IncrementalReleaseNotes.java
+++ b/src/main/groovy/org/shipkit/gradle/IncrementalReleaseNotes.java
@@ -75,7 +75,7 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
     }
 
     /**
-     * The tag prefix used for release note generation.
+     * See {@link ReleaseConfiguration.Git#getTagPrefix()}
      */
     @Input
     public String getTagPrefix() {

--- a/src/main/groovy/org/shipkit/gradle/IncrementalReleaseNotes.java
+++ b/src/main/groovy/org/shipkit/gradle/IncrementalReleaseNotes.java
@@ -41,6 +41,8 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
     private Collection<String> contributors;
     private File contributorsDataFile;
     private boolean emphasizeVersion;
+    private String version;
+    private String tagPrefix;
 
     /**
      * Release notes file this task operates on.
@@ -55,6 +57,34 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
      */
     public void setReleaseNotesFile(File releaseNotesFile) {
         this.releaseNotesFile = releaseNotesFile;
+    }
+
+    /**
+     * The version we are generating the release notes for.
+     */
+    @Input
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * See {@link #setVersion(String)}
+     * @param version
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * The tag prefix used for release note generation.
+     */
+    @Input
+    public String getTagPrefix() {
+        return tagPrefix;
+    }
+
+    public void setTagPrefix(String tagPrefix) {
+        this.tagPrefix = tagPrefix;
     }
 
     /**
@@ -215,9 +245,6 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
     String getNewContent() {
         assertConfigured();
         LOG.lifecycle("  Building new release notes based on {}", releaseNotesFile);
-
-        String version = getProject().getVersion().toString();
-        String tagPrefix = "v";
 
         Collection<ReleaseNotesData> data = new ReleaseNotesSerializer().deserialize(IOUtil.readFully(releaseNotesData));
 

--- a/src/main/groovy/org/shipkit/gradle/IncrementalReleaseNotes.java
+++ b/src/main/groovy/org/shipkit/gradle/IncrementalReleaseNotes.java
@@ -68,8 +68,7 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
     }
 
     /**
-     * See {@link #setVersion(String)}
-     * @param version
+     * See {@link #getVersion()}
      */
     public void setVersion(String version) {
         this.version = version;
@@ -83,6 +82,9 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
         return tagPrefix;
     }
 
+    /**
+     * See {@link #getTagPrefix()}
+     */
     public void setTagPrefix(String tagPrefix) {
         this.tagPrefix = tagPrefix;
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ReleaseNotesPlugin.java
@@ -81,7 +81,7 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
         task.dependsOn(contributorsFetcher);
 
         task.setVersion(project.getVersion().toString());
-        task.setTagPrefix("v");
+        task.setTagPrefix(conf.getGit().getTagPrefix());
 
         task.setDevelopers(conf.getTeam().getDevelopers());
         task.setContributors(conf.getTeam().getContributors());

--- a/src/main/groovy/org/shipkit/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ReleaseNotesPlugin.java
@@ -80,6 +80,9 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
         task.dependsOn(releaseNotesFetcher);
         task.dependsOn(contributorsFetcher);
 
+        task.setVersion(project.getVersion().toString());
+        task.setTagPrefix("v");
+
         task.setDevelopers(conf.getTeam().getDevelopers());
         task.setContributors(conf.getTeam().getContributors());
         task.setGitHubLabelMapping(conf.getReleaseNotes().getLabelMapping()); //TODO make it optional


### PR DESCRIPTION
fixes #201 

 - added task properties (marked with `@Input`)
 - set default values in `ReleaseNotesPlugin`