### PR TITLE
Make applying java-library plugin conditional on a property

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
@@ -78,8 +78,8 @@ public class ReleaseConfiguration {
     }
 
     /**
-     * org.shipkit.java-library plugin will be applied to every java subproject if this boolean
-     * is <code>true</code>.
+     * org.shipkit.java-library plugin will be applied to every java subproject (project that applies Gradle's 'java'
+     * plugin) if this boolean is <code>true</code>.
      */
     public boolean isReleaseAllJavaModules() {
         return releaseAllJavaModules;

--- a/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
@@ -52,6 +52,7 @@ public class ReleaseConfiguration {
     //TODO currently it's not clear when to use class fields and when to use the 'configuration' map
     //Let's make it clear in the docs
     private boolean dryRun = true;
+    private boolean releaseAllJavaModules = true;
 
     /**
      * See {@link #isDryRun()}
@@ -67,6 +68,21 @@ public class ReleaseConfiguration {
      */
     public boolean isDryRun() {
         return dryRun;
+    }
+
+    /**
+     * See {@link #isReleaseAllJavaModules()}}
+     */
+    public void setReleaseAllJavaModules(boolean releaseAllJavaModules) {
+        this.releaseAllJavaModules = releaseAllJavaModules;
+    }
+
+    /**
+     * org.shipkit.java-library plugin will be applied to every java subproject if this boolean
+     * is <code>true</code>.
+     */
+    public boolean isReleaseAllJavaModules() {
+        return releaseAllJavaModules;
     }
 
     public GitHub getGitHub() {

--- a/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
@@ -52,7 +52,7 @@ public class ReleaseConfiguration {
     //TODO currently it's not clear when to use class fields and when to use the 'configuration' map
     //Let's make it clear in the docs
     private boolean dryRun = true;
-    private boolean releaseAllJavaModules = true;
+    private boolean publishAllJavaSubprojects = true;
 
     /**
      * See {@link #isDryRun()}
@@ -71,18 +71,18 @@ public class ReleaseConfiguration {
     }
 
     /**
-     * See {@link #isReleaseAllJavaModules()}}
+     * See {@link #isPublishAllJavaSubprojects()}}
      */
-    public void setReleaseAllJavaModules(boolean releaseAllJavaModules) {
-        this.releaseAllJavaModules = releaseAllJavaModules;
+    public void setPublishAllJavaSubprojects(boolean publishAllJavaSubprojects) {
+        this.publishAllJavaSubprojects = publishAllJavaSubprojects;
     }
 
     /**
      * org.shipkit.java-library plugin will be applied to every java subproject (project that applies Gradle's 'java'
      * plugin) if this boolean is <code>true</code>.
      */
-    public boolean isReleaseAllJavaModules() {
-        return releaseAllJavaModules;
+    public boolean isPublishAllJavaSubprojects() {
+        return publishAllJavaSubprojects;
     }
 
     public GitHub getGitHub() {

--- a/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
@@ -53,7 +53,7 @@ public class ShipkitJavaPlugin implements Plugin<Project> {
         project.allprojects(new Action<Project>() {
             @Override
             public void execute(final Project subproject) {
-                if (conf.isReleaseAllJavaModules()) {
+                if (conf.isPublishAllJavaSubprojects()) {
                     subproject.getPlugins().withId("java", new Action<Plugin>() {
                         @Override
                         public void execute(Plugin plugin) {

--- a/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
@@ -53,12 +53,14 @@ public class ShipkitJavaPlugin implements Plugin<Project> {
         project.allprojects(new Action<Project>() {
             @Override
             public void execute(final Project subproject) {
-                subproject.getPlugins().withId("java", new Action<Plugin>() {
-                    @Override
-                    public void execute(Plugin plugin) {
-                        subproject.getPlugins().apply(JavaLibraryPlugin.class);
-                    }
-                });
+                if (conf.isReleaseAllJavaModules()) {
+                    subproject.getPlugins().withId("java", new Action<Plugin>() {
+                        @Override
+                        public void execute(Plugin plugin) {
+                            subproject.getPlugins().apply(JavaLibraryPlugin.class);
+                        }
+                    });
+                }
 
                 subproject.getPlugins().withType(BaseJavaLibraryPlugin.class, new Action<BaseJavaLibraryPlugin>() {
                     @Override


### PR DESCRIPTION
fixes #200 

introduced `shipkit.releaseAllJavaModules` (which defaults to `true`). If the property mentioned is `true` we'll apply `java-library` to every subproject (which does have the `java` plugin applied).