### PR TITLE
PreviewReleaseNotes and updateReleaseNotes merged into one task #205

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,11 @@ It should use the same version that was built in the previous step.
 3. Basic testing (for most contributors):
  - Smoke test (no tasks are run): ```./gradlew testRelease -m```
  - Test most things, without actually making any code pushes/publications: ```./gradlew testRelease -x gitPush -x bintrayUpload```
- - Release notes content: ```./gradlew previewReleaseNotes```
-    To generate sizable release notes content, before running 'previewReleaseNotes' you can downgrade the 'previousVersion' in 'version.properties'.
+ - Release notes content: ```./gradlew updateReleaseNotes -Ppreview```
+    To generate sizable release notes content, before running 'updateReleaseNotes' you can downgrade the 'previousVersion' in 'version.properties'.
     Release notes are generated from 'previousVersion' to current 'version' as declared in 'version.properties' file.
 4. Advanced testing (occasionally, for core developers, edge cases):
- - Release notes in file: ```./gradlew previewReleaseNotes```, then inspect updated file
+ - Release notes in file: ```./gradlew updateReleaseNotes```, then inspect updated file
  - Test release needed task: ```./gradlew assertReleaseNeeded```
  - If you are one of the core developers you can export env variables and even test git push and bintray upload.
  Run ```./gradlew testRelease``` follow the prompts and export necessary env variables.

--- a/src/main/groovy/org/shipkit/gradle/UpdateReleaseNotesTask.java
+++ b/src/main/groovy/org/shipkit/gradle/UpdateReleaseNotesTask.java
@@ -19,17 +19,20 @@ import org.shipkit.internal.notes.model.Contributor;
 import org.shipkit.internal.notes.model.ProjectContributor;
 import org.shipkit.internal.notes.model.ReleaseNotesData;
 import org.shipkit.internal.notes.util.IOUtil;
+import org.shipkit.internal.util.ExposedForTesting;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.*;
 
 /**
  * Generates incremental, detailed release notes text.
- * that can be appended to the release notes file.
+ * that can be appended to the release notes file or displayed in console as a preview.
  */
-public abstract class IncrementalReleaseNotes extends DefaultTask {
+public class UpdateReleaseNotesTask extends DefaultTask {
 
-    private static final Logger LOG = Logging.getLogger(IncrementalReleaseNotes.class);
+    private static final Logger LOG = Logging.getLogger(UpdateReleaseNotesTask.class);
+    public static final String PREVIEW_PROJECT_PROPERTY = "preview";
 
     private String previousVersion;
     private File releaseNotesFile;
@@ -41,11 +44,34 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
     private Collection<String> contributors;
     private File contributorsDataFile;
     private boolean emphasizeVersion;
+    private IncrementalNotesGenerator incrementalNotesGenerator = new IncrementalNotesGenerator();
+
+    /**
+     * Generates incremental release notes and appends it to the top of release notes file.
+     * Run with -Ppreview if you only want to see preview of generated release notes, without appending them to the file.
+     */
+    @TaskAction
+    public void updateReleaseNotes() {
+        String newContent = getNewContent();
+        if (isInPreviewMode()){
+            LOG.lifecycle("  Preview of release notes update:\n" +
+                    "  ----------------\n" + newContent + "----------------");
+        } else{
+            FileUtil.appendToTop(newContent, getReleaseNotesFile());
+            LOG.lifecycle("  Successfully updated release notes!");
+        }
+    }
+
+    /**
+     * @return true if task is configured to generate only preview of release notes, and false otherwise
+     */
+    public boolean isInPreviewMode() {
+        return getProject().hasProperty(PREVIEW_PROJECT_PROPERTY);
+    }
 
     /**
      * Release notes file this task operates on.
      */
-    @InputFile
     public File getReleaseNotesFile() {
         return releaseNotesFile;
     }
@@ -199,14 +225,27 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
     }
 
     private void assertConfigured() {
-        //TODO SF unit test coverage
-        if (releaseNotesFile == null || !releaseNotesFile.isFile()) {
-            throw new GradleException("'" + this.getPath() + ".releaseNotesFile' must be configured and the file must be present.");
+        if (gitHubRepository == null || gitHubRepository.trim().isEmpty()) {
+            throw new GradleException("'" + this.getPath() + ".gitHubRepository' must be configured.");
         }
 
-        if (gitHubRepository == null || gitHubRepository.trim().isEmpty()) {
-            throw new GradleException("'" + this.getPath() + "gitHubRepository' must be configured.");
+        if(!isInPreviewMode()) { // releaseNotesFile is not needed in preview mode
+            if (releaseNotesFile == null) {
+                throw new GradleException("'" + this.getPath() + ".releaseNotesFile' must be configured.");
+            }
+            if(releaseNotesFile.exists() && !releaseNotesFile.isFile()){
+                throw new GradleException("'" + this.getPath() + ".releaseNotesFile' must be a file.");
+            }
+            if(!releaseNotesFile.exists()){
+                IOUtil.createParentDirectory(releaseNotesFile);
+                try {
+                    releaseNotesFile.createNewFile();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
         }
+
     }
 
     /**
@@ -214,31 +253,12 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
      */
     String getNewContent() {
         assertConfigured();
-        LOG.lifecycle("  Building new release notes based on {}", releaseNotesFile);
+        return incrementalNotesGenerator.generateNewContent();
+    }
 
-        String version = getProject().getVersion().toString();
-        String tagPrefix = "v";
-
-        Collection<ReleaseNotesData> data = new ReleaseNotesSerializer().deserialize(IOUtil.readFully(releaseNotesData));
-
-        String vcsCommitTemplate = "https://github.com/" + gitHubRepository + "/compare/"
-                + tagPrefix + previousVersion + "..." + tagPrefix + version;
-
-        ProjectContributorsSet contributorsFromGitHub;
-        if(!contributors.isEmpty()) {
-            // if contributors are defined in shipkit.team.contributors don't deserialize them from file
-            contributorsFromGitHub = new DefaultProjectContributorsSet();
-        } else {
-            LOG.info("  Read project contributors from file " + contributorsDataFile.getAbsolutePath());
-            contributorsFromGitHub = new AllContributorsSerializer().deserialize(IOUtil.readFully(contributorsDataFile));
-        }
-
-        Map<String, Contributor> contributorsMap = contributorsMap(contributors, contributorsFromGitHub, developers);
-        String notes = ReleaseNotesFormatters.detailedFormatter(
-                "", gitHubLabelMapping, vcsCommitTemplate, publicationRepository, contributorsMap, emphasizeVersion)
-                .formatReleaseNotes(data);
-
-        return notes + "\n\n";
+    @ExposedForTesting
+    void setIncrementalNotesGenerator(IncrementalNotesGenerator incrementalNotesGenerator){
+        this.incrementalNotesGenerator = incrementalNotesGenerator;
     }
 
     //TODO SF deduplicate and unit test
@@ -262,36 +282,35 @@ public abstract class IncrementalReleaseNotes extends DefaultTask {
         return out;
     }
 
-    /**
-     * Generates incremental, detailed release notes text
-     * and appends it to the top of the release notes file.
-     */
-    public static class UpdateTask extends IncrementalReleaseNotes {
 
-        /**
-         * Delegates to {@link IncrementalReleaseNotes#getReleaseNotesFile()}.
-         * Configured here only to specify Gradle's output file and make the task incremental.
-         */
-        @OutputFile
-        public File getReleaseNotesFile() {
-            return super.getReleaseNotesFile();
-        }
 
-        @TaskAction public void updateReleaseNotes() {
-            String newContent = super.getNewContent();
-            FileUtil.appendToTop(newContent, getReleaseNotesFile());
-            LOG.lifecycle("  Successfully updated release notes!");
-        }
-    }
+    class IncrementalNotesGenerator {
+        public String generateNewContent() {
+            LOG.lifecycle("  Building new release notes based on {}", releaseNotesFile);
 
-    /**
-     * Generates incremental, detailed release notes text
-     * and appends it to the top of the release notes file.
-     */
-    public static class PreviewTask extends IncrementalReleaseNotes {
-        @TaskAction public void updateReleaseNotes() {
-            String newContent = super.getNewContent();
-            LOG.lifecycle("----------------\n" + newContent + "----------------");
+            String version = getProject().getVersion().toString();
+            String tagPrefix = "v";
+
+            Collection<ReleaseNotesData> data = new ReleaseNotesSerializer().deserialize(IOUtil.readFully(releaseNotesData));
+
+            String vcsCommitTemplate = "https://github.com/" + gitHubRepository + "/compare/"
+                    + tagPrefix + previousVersion + "..." + tagPrefix + version;
+
+            ProjectContributorsSet contributorsFromGitHub;
+            if(!contributors.isEmpty()) {
+                // if contributors are defined in shipkit.team.contributors don't deserialize them from file
+                contributorsFromGitHub = new DefaultProjectContributorsSet();
+            } else {
+                LOG.info("  Read project contributors from file " + contributorsDataFile.getAbsolutePath());
+                contributorsFromGitHub = new AllContributorsSerializer().deserialize(IOUtil.readFully(contributorsDataFile));
+            }
+
+            Map<String, Contributor> contributorsMap = contributorsMap(contributors, contributorsFromGitHub, developers);
+            String notes = ReleaseNotesFormatters.detailedFormatter(
+                    "", gitHubLabelMapping, vcsCommitTemplate, publicationRepository, contributorsMap, emphasizeVersion)
+                    .formatReleaseNotes(data);
+
+            return notes + "\n\n";
         }
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ReleaseNotesPlugin.java
@@ -19,7 +19,7 @@ import static org.shipkit.internal.gradle.configuration.DeferredConfiguration.de
  *
  * <ul>
  *     <li>fetchReleaseNotes - fetches release notes data, see {@link ReleaseNotesFetcherTask}</li>
- *     <li>updateReleaseNotes - updates release notes file in place, or only displays preview, see {@link UpdateReleaseNotesTask}</li>
+ *     <li>updateReleaseNotes - updates release notes file in place, or only displays preview if project property 'preview' exists, see {@link UpdateReleaseNotesTask}</li>
  * </ul>
  *
  * It also adds updates release notes changes if {@link GitPlugin} applied
@@ -58,7 +58,10 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
 
                 configureDetailedNotes(t, releaseNotesFetcher, project, conf, contributorsFetcher);
 
-                if(!t.isInPreviewMode()){
+                boolean previewMode = project.hasProperty(UpdateReleaseNotesTask.PREVIEW_PROJECT_PROPERTY);
+                t.setPreviewMode(previewMode);
+
+                if(!previewMode){
                     File releaseNotesFile = project.file(conf.getReleaseNotes().getFile());
                     GitPlugin.registerChangesForCommitIfApplied(
                         Arrays.asList(releaseNotesFile), "release notes updated", t);

--- a/src/main/groovy/org/shipkit/internal/gradle/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ReleaseNotesPlugin.java
@@ -3,7 +3,7 @@ package org.shipkit.internal.gradle;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.shipkit.gradle.IncrementalReleaseNotes;
+import org.shipkit.gradle.UpdateReleaseNotesTask;
 import org.shipkit.gradle.ReleaseConfiguration;
 import org.shipkit.gradle.ReleaseNotesFetcherTask;
 import org.shipkit.internal.gradle.util.TaskMaker;
@@ -19,9 +19,7 @@ import static org.shipkit.internal.gradle.configuration.DeferredConfiguration.de
  *
  * <ul>
  *     <li>fetchReleaseNotes - fetches release notes data, see {@link ReleaseNotesFetcherTask}</li>
- *     <li>updateReleaseNotes - updates release notes file in place, see {@link IncrementalReleaseNotes.UpdateTask}</li>
- *     <li>previewReleaseNotes - prints incremental release notes to the console for preview,
- *          see {@link IncrementalReleaseNotes.PreviewTask}</li>
+ *     <li>updateReleaseNotes - updates release notes file in place, or only displays preview, see {@link UpdateReleaseNotesTask}</li>
  * </ul>
  *
  * It also adds updates release notes changes if {@link GitPlugin} applied
@@ -30,7 +28,6 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
 
     private static final String FETCH_NOTES_TASK = "fetchReleaseNotes";
     public static final String UPDATE_NOTES_TASK = "updateReleaseNotes";
-    private static final String PREVIEW_NOTES_TASK = "previewReleaseNotes";
 
     public void apply(final Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
@@ -55,24 +52,23 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
 
         final AllContributorsFetcherTask contributorsFetcher = (AllContributorsFetcherTask) project.getTasks().getByName(ContributorsPlugin.FETCH_ALL_CONTRIBUTORS_TASK);
 
-        TaskMaker.task(project, UPDATE_NOTES_TASK, IncrementalReleaseNotes.UpdateTask.class, new Action<IncrementalReleaseNotes.UpdateTask>() {
-            public void execute(final IncrementalReleaseNotes.UpdateTask t) {
-                t.setDescription("Updates release notes file.");
-                configureDetailedNotes(t, releaseNotesFetcher, project, conf, contributorsFetcher);
-                GitPlugin.registerChangesForCommitIfApplied(
-                        Arrays.asList(project.file(conf.getReleaseNotes().getFile())), "release notes updated", t);
-            }
-        });
+        TaskMaker.task(project, UPDATE_NOTES_TASK, UpdateReleaseNotesTask.class, new Action<UpdateReleaseNotesTask>() {
+            public void execute(final UpdateReleaseNotesTask t) {
+                t.setDescription("Updates release notes file. Run with '-Ppreview' if you only want to see the preview.");
 
-        TaskMaker.task(project, PREVIEW_NOTES_TASK, IncrementalReleaseNotes.PreviewTask.class, new Action<IncrementalReleaseNotes.PreviewTask>() {
-            public void execute(final IncrementalReleaseNotes.PreviewTask t) {
-                t.setDescription("Shows new incremental content of release notes. Useful for previewing the release notes.");
                 configureDetailedNotes(t, releaseNotesFetcher, project, conf, contributorsFetcher);
+
+                if(!t.isInPreviewMode()){
+                    File releaseNotesFile = project.file(conf.getReleaseNotes().getFile());
+                    GitPlugin.registerChangesForCommitIfApplied(
+                        Arrays.asList(releaseNotesFile), "release notes updated", t);
+                    t.getOutputs().file(releaseNotesFile);
+                }
             }
         });
     }
 
-    private static void configureDetailedNotes(final IncrementalReleaseNotes task,
+    private static void configureDetailedNotes(final UpdateReleaseNotesTask task,
                                                final ReleaseNotesFetcherTask releaseNotesFetcher,
                                                final Project project,
                                                final ReleaseConfiguration conf,

--- a/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
@@ -4,7 +4,7 @@ import com.jfrog.bintray.gradle.BintrayExtension;
 import org.gradle.api.*;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.shipkit.gradle.IncrementalReleaseNotes;
+import org.shipkit.gradle.UpdateReleaseNotesTask;
 import org.shipkit.gradle.ReleaseConfiguration;
 import org.shipkit.internal.gradle.util.BintrayUtil;
 import org.shipkit.internal.gradle.util.TaskMaker;
@@ -159,8 +159,8 @@ public class ShipkitJavaPlugin implements Plugin<Project> {
         //not using 'getTasks().withType()' because I don't want to create too many task configuration rules
         //TODO add information about it in the development guide
         for (Task t : project.getTasks()) {
-            if (t instanceof IncrementalReleaseNotes) {
-                IncrementalReleaseNotes task = (IncrementalReleaseNotes) t;
+            if (t instanceof UpdateReleaseNotesTask) {
+                UpdateReleaseNotesTask task = (UpdateReleaseNotesTask) t;
                 if (task.getPublicationRepository() == null) {
                     LOG.info("Configuring publication repository '{}' on task: {}", bintrayRepo, t.getPath());
                     task.setPublicationRepository(bintrayRepo);

--- a/src/test/groovy/org/shipkit/gradle/UpdateReleaseNotesTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/gradle/UpdateReleaseNotesTaskTest.groovy
@@ -105,8 +105,9 @@ class UpdateReleaseNotesTaskTest extends Specification {
         underTest.setGitHubRepository("https://github.com/mockito/mockito")
         incrementalNotesGenerator.generateNewContent() >> "content"
 
+        underTest.setPreviewMode(true)
+
         when:
-        project.extensions.add(UpdateReleaseNotesTask.PREVIEW_PROJECT_PROPERTY, "")
         underTest.updateReleaseNotes()
 
         then:

--- a/src/test/groovy/org/shipkit/gradle/UpdateReleaseNotesTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/gradle/UpdateReleaseNotesTaskTest.groovy
@@ -1,0 +1,115 @@
+package org.shipkit.gradle
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class UpdateReleaseNotesTaskTest extends Specification {
+
+    @Rule
+    TemporaryFolder tmp = new TemporaryFolder()
+
+    def project = new ProjectBuilder().build()
+    def tasks = project.getTasks();
+    UpdateReleaseNotesTask underTest = tasks.create("updateReleaseNotes", UpdateReleaseNotesTask)
+    def incrementalNotesGenerator = Mock(UpdateReleaseNotesTask.IncrementalNotesGenerator)
+
+    void setup(){
+        underTest.incrementalNotesGenerator = incrementalNotesGenerator
+    }
+
+
+    def "should fail if gitHubRepository null" (){
+        when:
+        underTest.updateReleaseNotes()
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message == "':updateReleaseNotes.gitHubRepository' must be configured."
+    }
+
+    def "should fail if gitHubRepository empty" (){
+        given:
+        underTest.gitHubRepository == ""
+
+        when:
+        underTest.updateReleaseNotes()
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message == "':updateReleaseNotes.gitHubRepository' must be configured."
+    }
+
+    def "should fail if releaseNotesFile is not configured and not in preview mode" (){
+        given:
+        underTest.gitHubRepository = "mockito/mockito"
+
+        when:
+        underTest.updateReleaseNotes()
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message == "':updateReleaseNotes.releaseNotesFile' must be configured."
+    }
+
+    def "should fail if releaseNotesFile is a directory and not in preview mode" (){
+        given:
+        underTest.gitHubRepository = "mockito/mockito"
+        def dir = tmp.newFolder("release-notes")
+        underTest.setReleaseNotesFile(dir)
+
+        when:
+        underTest.updateReleaseNotes()
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message == "':updateReleaseNotes.releaseNotesFile' must be a file."
+    }
+
+    def "should create releaseNotesFile automatically if does not exist and not in preview mode" (){
+        given:
+        def file = new File(tmp.root.absolutePath + "/docs/release-notes.md")
+        underTest.setReleaseNotesFile(file)
+        underTest.setGitHubRepository("https://github.com/mockito/mockito")
+
+        when:
+        underTest.updateReleaseNotes()
+
+        then:
+        file.parentFile.directory
+        file.file
+    }
+
+    def "should update release notes if not in preview mode" (){
+        given:
+        def file = tmp.newFile("release-notes.md")
+        file << ""
+        underTest.setReleaseNotesFile(file)
+        underTest.setGitHubRepository("https://github.com/mockito/mockito")
+        incrementalNotesGenerator.generateNewContent() >> "content"
+
+        when:
+        underTest.updateReleaseNotes()
+
+        then:
+        file.text == "content"
+    }
+
+    def "should not modify releaseNotesFile if in preview mode" (){
+        given:
+        def file = tmp.newFile("release-notes.md")
+        file << ""
+        underTest.setReleaseNotesFile(file)
+        underTest.setGitHubRepository("https://github.com/mockito/mockito")
+        incrementalNotesGenerator.generateNewContent() >> "content"
+
+        when:
+        project.extensions.add(UpdateReleaseNotesTask.PREVIEW_PROJECT_PROPERTY, "")
+        underTest.updateReleaseNotes()
+
+        then:
+        file.text == ""
+    }
+}


### PR DESCRIPTION
As discussed, both tasks replaced with one, preview can be displayed with parameter -Ppreview. 

I tested some of the functionality in IncrementalReleaseNotes and extracted rest of it into a separate local class, as the first step to improve the coverage. Next step would be to extract this class into a top level one and write tests for it.

@szczepiq 
Important - I removed @InputFile from IncrementalReleaseNotes/UpdateReleaseNotesTask#48. It didn't make sense there for me - releaseNotesFile is already @OutputFile (only NOT in preview mode) so it was always updated when the task was run and this task would never be UP-TO-DATE.