### PR TITLE
Fixed bintrayUploadTask configuration

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/BintrayPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/BintrayPlugin.java
@@ -104,6 +104,8 @@ public class BintrayPlugin implements Plugin<Project> {
                         "Missing 'bintray.key' value.\n" +
                         "  Please configure Bintray extension or export 'BINTRAY_API_KEY' env variable.");
                 bintray.setKey(key);
+                // api key is set basing on 'bintray.key' before lazy configuration so it has to be set again here
+                bintrayUpload.setApiKey(key);
 
                 //workaround for https://github.com/bintray/gradle-bintray-plugin/issues/170
                 notNull(bintray.getUser(), "Missing 'bintray.user' value.\n" +


### PR DESCRIPTION
It seems that bintrayUpload.apiKey property was set before lazyConfiguration, so it was NULL when running the task and because of that publishing failed silently.. 

Upload worked before because bintray.key was set in release.gradle. It was removed at this moment:
https://github.com/mockito/mockito-release-tools-example/commit/a56686ba4f737cd7e71d7212424e9f0ca9bc3718#diff-33cf41d9669aaef72ca19c641dc57d47L29

I tried it locally, it works, publishes artifacts, you can see results on Bintray in basic, versions 0.15.12 and 0.15.11